### PR TITLE
Changes to Workspace Override Commands, TableConstraintCommandProvider, ExitCommand

### DIFF
--- a/plugins/org.komodo.core/src/org/komodo/repository/Messages.java
+++ b/plugins/org.komodo.core/src/org/komodo/repository/Messages.java
@@ -78,6 +78,12 @@ public class Messages implements StringConstants {
 
         DUPLICATE_OBJECT_ERROR,
         ERROR_ADDING_ARTIFACT,
+
+        /**
+         * Indicates an error occurred determining if a repository has unsaved changes.
+         */
+        ERROR_REPO_HAS_CHANGES,
+
         ERROR_SESSION_IS_CLOSED,
 
         /**

--- a/plugins/org.komodo.core/src/org/komodo/repository/RepositoryImpl.java
+++ b/plugins/org.komodo.core/src/org/komodo/repository/RepositoryImpl.java
@@ -7,6 +7,7 @@
  */
 package org.komodo.repository;
 
+import static org.komodo.repository.Messages.Komodo.ERROR_REPO_HAS_CHANGES;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -18,6 +19,7 @@ import java.util.Set;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.PropertyIterator;
+import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.Value;
 import javax.jcr.ValueFactory;
@@ -304,6 +306,24 @@ public abstract class RepositoryImpl implements Repository, StringConstants {
         @Override
         public State getState() {
             return this.state;
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.spi.repository.Repository.UnitOfWork#hasChanges()
+         */
+        @Override
+        public boolean hasChanges() throws KException {
+            if ( this.state == State.RUNNING ) {
+                try {
+                    return ( ( this.session != null ) && this.session.isLive() && this.session.hasPendingChanges() );
+                } catch ( final RepositoryException e ) {
+                    throw new KException( Messages.getString( ERROR_REPO_HAS_CHANGES, this.name ), e );
+                }
+            }
+
+            return false;
         }
 
         /**

--- a/plugins/org.komodo.core/src/org/komodo/repository/messages.properties
+++ b/plugins/org.komodo.core/src/org/komodo/repository/messages.properties
@@ -21,6 +21,7 @@ Komodo.CHILD_NOT_FOUND = A child named "{0}" at parent path "{1}" does not exist
 Komodo.DESCRIPTOR_NOT_FOUND = A descriptor named "{0}" for node at "{1}" does not exist
 Komodo.DUPLICATE_OBJECT_ERROR = More than one object found for UUID "{0}"
 Komodo.ERROR_ADDING_ARTIFACT = Error adding artifact "{0}" at path "{1}"
+Komodo.ERROR_REPO_HAS_CHANGES = Error occurred determining if transaction "{0}" had pending changes.
 Komodo.ERROR_SESSION_IS_CLOSED = Error trying to use transaction "{0}" but the session has been closed
 Komodo.ERROR_TRANSACTION_FINISHED = Error trying to use old transaction "{0}" whose state is "{1}"
 Komodo.ERROR_TRYING_TO_COMMIT = Error committing transaction "{0}"

--- a/plugins/org.komodo.relational/META-INF/services/org.komodo.shell.api.ShellCommandProvider
+++ b/plugins/org.komodo.relational/META-INF/services/org.komodo.shell.api.ShellCommandProvider
@@ -15,6 +15,7 @@ org.komodo.relational.commands.schema.SchemaCommandProvider
 org.komodo.relational.commands.server.ServerCommandProvider
 org.komodo.relational.commands.storedprocedure.StoredProcedureCommandProvider
 org.komodo.relational.commands.table.TableCommandProvider
+org.komodo.relational.commands.tableconstraint.TableConstraintCommandProvider
 org.komodo.relational.commands.teiid.TeiidCommandProvider
 org.komodo.relational.commands.translator.TranslatorCommandProvider
 org.komodo.relational.commands.userdefinedfunction.UserDefinedFunctionCommandProvider

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/CreateTeiidCommand.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/CreateTeiidCommand.java
@@ -14,12 +14,11 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.CommandResultImpl;
 import org.komodo.shell.api.CommandResult;
 import org.komodo.shell.api.WorkspaceStatus;
-import org.komodo.spi.repository.KomodoType;
 
 /**
  * A shell command to create a Teiid object.
  */
-public final class CreateTeiidCommand extends RelationalShellCommand {
+public final class CreateTeiidCommand extends WorkspaceShellCommand {
 
     static final String NAME = "create-teiid"; //$NON-NLS-1$
 
@@ -62,23 +61,6 @@ public final class CreateTeiidCommand extends RelationalShellCommand {
     @Override
     protected int getMaxArgCount() {
         return 1;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.komodo.shell.api.ShellCommand#isValidForCurrentContext()
-     */
-    @Override
-    public boolean isValidForCurrentContext() {
-        // Only allow Teiid create in the workspace
-        try {
-            KomodoType contextType = getContext().getTypeIdentifier(getTransaction());
-            return contextType==KomodoType.WORKSPACE;
-        } catch (Exception ex) {
-            // on exception will return false
-        }
-        return false;
     }
 
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/CreateVdbCommand.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/CreateVdbCommand.java
@@ -15,12 +15,11 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.CommandResultImpl;
 import org.komodo.shell.api.CommandResult;
 import org.komodo.shell.api.WorkspaceStatus;
-import org.komodo.spi.repository.KomodoType;
 
 /**
  * A shell command to create a VDB.
  */
-public final class CreateVdbCommand extends RelationalShellCommand {
+public final class CreateVdbCommand extends WorkspaceShellCommand {
 
     static final String NAME = "create-vdb"; //$NON-NLS-1$
 
@@ -64,23 +63,6 @@ public final class CreateVdbCommand extends RelationalShellCommand {
     @Override
     protected int getMaxArgCount() {
         return 2;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.komodo.shell.api.ShellCommand#isValidForCurrentContext()
-     */
-    @Override
-    public boolean isValidForCurrentContext() {
-        // Only allow VDB create in the workspace
-        try {
-            KomodoType contextType = getContext().getTypeIdentifier(getTransaction());
-            return contextType==KomodoType.WORKSPACE;
-        } catch (Exception ex) {
-            // on exception will return false
-        }
-        return false;
     }
 
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/WorkspaceCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/WorkspaceCommandProvider.java
@@ -44,6 +44,8 @@ public class WorkspaceCommandProvider implements ShellCommandProvider {
         result.put( CreateVdbCommand.NAME, CreateVdbCommand.class );
         result.put( FindCommand.NAME, FindCommand.class );
         result.put( SetCustomPropertyCommand.NAME, SetCustomPropertyCommand.class );
+        result.put( WorkspaceSetPropertyCommand.NAME, WorkspaceSetPropertyCommand.class );
+        result.put( WorkspaceUnsetPropertyCommand.NAME, WorkspaceUnsetPropertyCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/WorkspaceSetPropertyCommand.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/WorkspaceSetPropertyCommand.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
+package org.komodo.relational.commands;
+
+import org.komodo.shell.api.CommandResult;
+import org.komodo.shell.api.WorkspaceStatus;
+import org.komodo.shell.commands.SetPropertyCommand;
+
+/**
+ * A disabled shell command that overrides the default set property command. The workspace does not have any editable properties.
+ */
+public final class WorkspaceSetPropertyCommand extends WorkspaceShellCommand {
+
+    static final String NAME = SetPropertyCommand.NAME; // override
+
+    /**
+     * @param status
+     *        the shell's workspace status (cannot be <code>null</code>)
+     */
+    public WorkspaceSetPropertyCommand( final WorkspaceStatus status ) {
+        super( status, NAME );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#doExecute()
+     */
+    @Override
+    protected CommandResult doExecute() {
+        assert false;
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#getMaxArgCount()
+     */
+    @Override
+    protected int getMaxArgCount() {
+        return 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#isEnabled()
+     */
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+
+}

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/WorkspaceShellCommand.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/WorkspaceShellCommand.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
+package org.komodo.relational.commands;
+
+import static org.komodo.relational.commands.WorkspaceCommandMessages.RESOURCE_BUNDLE;
+import org.komodo.relational.Messages;
+import org.komodo.relational.workspace.WorkspaceManager;
+import org.komodo.shell.api.WorkspaceStatus;
+import org.komodo.spi.repository.KomodoType;
+
+/**
+ * A base class for @{link {@link WorkspaceManager workspace manager}-related shell commands.
+ */
+abstract class WorkspaceShellCommand extends RelationalShellCommand {
+
+    protected WorkspaceShellCommand( final WorkspaceStatus status,
+                                     final String name ) {
+        super( status, name );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.commands.RelationalShellCommand#getMessage(java.lang.Enum, java.lang.Object[])
+     */
+    @Override
+    protected String getMessage( final Enum< ? > key,
+                                 final Object... parameters ) {
+        return Messages.getString( RESOURCE_BUNDLE, key.toString(), parameters );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommand#isValidForCurrentContext()
+     */
+    @Override
+    public final boolean isValidForCurrentContext() {
+        try {
+            final KomodoType contextType = getContext().getTypeIdentifier( getTransaction() );
+            return ( contextType == KomodoType.WORKSPACE );
+        } catch ( final Exception e ) {
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.commands.RelationalShellCommand#printHelp(int)
+     */
+    @Override
+    public void printHelp( final int indent ) {
+        print( indent, Messages.getString( RESOURCE_BUNDLE, getClass().getSimpleName() + ".help" ) ); //$NON-NLS-1$
+    }
+
+    /**
+     * @see org.komodo.shell.api.ShellCommand#printUsage(int indent)
+     */
+    @Override
+    public void printUsage( final int indent ) {
+        print( indent, Messages.getString( RESOURCE_BUNDLE, getClass().getSimpleName() + ".usage" ) ); //$NON-NLS-1$
+    }
+
+}

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/WorkspaceUnsetPropertyCommand.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/WorkspaceUnsetPropertyCommand.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
+package org.komodo.relational.commands;
+
+import org.komodo.shell.api.CommandResult;
+import org.komodo.shell.api.WorkspaceStatus;
+import org.komodo.shell.commands.UnsetPropertyCommand;
+
+/**
+ * A disabled shell command that overrides the default {@link UnsetPropertyCommand unset property} command. The workspace does not
+ * have any editable properties.
+ */
+public final class WorkspaceUnsetPropertyCommand extends WorkspaceShellCommand {
+
+    static final String NAME = UnsetPropertyCommand.NAME; // override
+
+    /**
+     * @param status
+     *        the shell's workspace status (cannot be <code>null</code>)
+     */
+    public WorkspaceUnsetPropertyCommand( final WorkspaceStatus status ) {
+        super( status, NAME );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#doExecute()
+     */
+    @Override
+    protected CommandResult doExecute() {
+        assert false;
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#getMaxArgCount()
+     */
+    @Override
+    protected int getMaxArgCount() {
+        return 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#isEnabled()
+     */
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+
+}

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/column/ColumnCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/column/ColumnCommandProvider.java
@@ -66,10 +66,8 @@ public class ColumnCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(ColumnImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/condition/ConditionCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/condition/ConditionCommandProvider.java
@@ -66,10 +66,8 @@ public class ConditionCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(ConditionImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/datarole/DataRoleCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/datarole/DataRoleCommandProvider.java
@@ -70,10 +70,8 @@ public class DataRoleCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(DataRoleImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/entry/EntryCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/entry/EntryCommandProvider.java
@@ -66,10 +66,8 @@ public class EntryCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(EntryImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/foreignkey/ForeignKeyCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/foreignkey/ForeignKeyCommandProvider.java
@@ -66,10 +66,8 @@ public class ForeignKeyCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(ForeignKeyImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/index/IndexCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/index/IndexCommandProvider.java
@@ -66,10 +66,8 @@ public class IndexCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(IndexImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/mask/MaskCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/mask/MaskCommandProvider.java
@@ -66,10 +66,8 @@ public class MaskCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(MaskImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/model/ModelCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/model/ModelCommandProvider.java
@@ -82,10 +82,8 @@ public class ModelCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(ModelImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/modelsource/ModelSourceCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/modelsource/ModelSourceCommandProvider.java
@@ -66,10 +66,8 @@ public class ModelSourceCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(ModelSourceImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/parameter/ParameterCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/parameter/ParameterCommandProvider.java
@@ -66,10 +66,8 @@ public class ParameterCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(ParameterImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/permission/PermissionCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/permission/PermissionCommandProvider.java
@@ -66,10 +66,8 @@ public class PermissionCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(PermissionImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/pushdownfunction/PushdownFunctionCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/pushdownfunction/PushdownFunctionCommandProvider.java
@@ -70,10 +70,8 @@ public class PushdownFunctionCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(PushdownFunctionImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/schema/SchemaCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/schema/SchemaCommandProvider.java
@@ -66,10 +66,8 @@ public class SchemaCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(SchemaImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/server/ServerCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/server/ServerCommandProvider.java
@@ -85,10 +85,8 @@ public class ServerCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(TeiidImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/storedprocedure/StoredProcedureCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/storedprocedure/StoredProcedureCommandProvider.java
@@ -70,10 +70,8 @@ public class StoredProcedureCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(StoredProcedureImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/table/TableCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/table/TableCommandProvider.java
@@ -78,10 +78,8 @@ public class TableCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(TableImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/tableconstraint/AddConstraintColumnCommand.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/tableconstraint/AddConstraintColumnCommand.java
@@ -5,7 +5,7 @@
  *
  * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
  */
-package org.komodo.relational.commands;
+package org.komodo.relational.commands.tableconstraint;
 
 import static org.komodo.relational.commands.WorkspaceCommandMessages.AddConstraintColumnCommand.ADD_COLUMN_ERROR;
 import static org.komodo.relational.commands.WorkspaceCommandMessages.AddConstraintColumnCommand.COLUMN_PATH_NOT_FOUND;
@@ -15,6 +15,8 @@ import static org.komodo.relational.commands.WorkspaceCommandMessages.AddConstra
 import static org.komodo.relational.commands.WorkspaceCommandMessages.AddConstraintColumnCommand.MISSING_COLUMN_PATH;
 import java.util.Arrays;
 import java.util.List;
+import org.komodo.relational.commands.FindCommand;
+import org.komodo.relational.commands.RelationalShellCommand;
 import org.komodo.relational.model.Column;
 import org.komodo.relational.model.TableConstraint;
 import org.komodo.relational.model.internal.AccessPatternImpl;
@@ -119,7 +121,7 @@ public final class AddConstraintColumnCommand extends RelationalShellCommand {
                    || IndexImpl.RESOLVER.resolvable( uow, kobject )
                    || PrimaryKeyImpl.RESOLVER.resolvable( uow, kobject )
                    || UniqueConstraintImpl.RESOLVER.resolvable( uow, kobject );
-        } catch ( Exception ex ) {
+        } catch ( final Exception e ) {
             return false;
         }
     }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/tableconstraint/TableConstraintCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/tableconstraint/TableConstraintCommandProvider.java
@@ -1,0 +1,137 @@
+/*
+ * JBoss, Home of Professional Open Source.
+*
+* See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+*
+* See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+*/
+package org.komodo.relational.commands.tableconstraint;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.komodo.relational.model.TableConstraint;
+import org.komodo.relational.model.internal.AccessPatternImpl;
+import org.komodo.relational.model.internal.ForeignKeyImpl;
+import org.komodo.relational.model.internal.IndexImpl;
+import org.komodo.relational.model.internal.PrimaryKeyImpl;
+import org.komodo.relational.model.internal.UniqueConstraintImpl;
+import org.komodo.shell.api.ShellCommand;
+import org.komodo.shell.api.ShellCommandProvider;
+import org.komodo.shell.api.WorkspaceStatus;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+
+/**
+ * A shell command provider for {@link TableConstraint}s.
+ */
+public class TableConstraintCommandProvider implements ShellCommandProvider {
+
+    /**
+     * Constructs a command provider for {@link TableConstraint} shell commands.
+     */
+    public TableConstraintCommandProvider() {
+        // nothing to do
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      org.komodo.spi.repository.KomodoObject)
+     */
+    @Override
+    public String getStatusMessage( final UnitOfWork uow,
+                                    final KomodoObject kObj ) {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      org.komodo.spi.repository.KomodoObject)
+     */
+    @Override
+    public String getTypeDisplay( final UnitOfWork uow,
+                                  final KomodoObject kObject ) throws KException {
+        final TableConstraint constraint = resolve( uow, kObject );
+
+        if (constraint == null) {
+            return null;
+        }
+
+        return constraint.getTypeDisplayName();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommandProvider#initWorkspaceState(org.komodo.shell.api.WorkspaceStatus)
+     */
+    @Override
+    public void initWorkspaceState( final WorkspaceStatus wsStatus ) {
+        // nothing to do
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommandProvider#isRoot(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      org.komodo.spi.repository.KomodoObject)
+     */
+    @Override
+    public boolean isRoot( final UnitOfWork uow,
+                           final KomodoObject kObject ) {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
+     */
+    @Override
+    public Map< String, Class< ? extends ShellCommand > > provideCommands() {
+        final Map< String, Class< ? extends ShellCommand > > result = new HashMap< >();
+
+        result.put( AddConstraintColumnCommand.NAME, AddConstraintColumnCommand.class );
+        result.put( DeleteConstraintColumnCommand.NAME, DeleteConstraintColumnCommand.class );
+
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommandProvider#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      org.komodo.spi.repository.KomodoObject)
+     */
+    @SuppressWarnings( "unchecked" )
+    @Override
+    public TableConstraint resolve( final UnitOfWork uow,
+                                    final KomodoObject kObject ) throws KException {
+        if ( PrimaryKeyImpl.RESOLVER.resolvable( uow, kObject ) ) {
+            return PrimaryKeyImpl.RESOLVER.resolve( uow, kObject );
+        }
+
+        if ( ForeignKeyImpl.RESOLVER.resolvable( uow, kObject ) ) {
+            return ForeignKeyImpl.RESOLVER.resolve( uow, kObject );
+        }
+
+        if ( IndexImpl.RESOLVER.resolvable( uow, kObject ) ) {
+            return IndexImpl.RESOLVER.resolve( uow, kObject );
+        }
+
+        if ( AccessPatternImpl.RESOLVER.resolvable( uow, kObject ) ) {
+            return AccessPatternImpl.RESOLVER.resolve( uow, kObject );
+        }
+
+        if ( UniqueConstraintImpl.RESOLVER.resolvable( uow, kObject ) ) {
+            return UniqueConstraintImpl.RESOLVER.resolve( uow, kObject );
+        }
+
+        return null;
+    }
+
+}

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/teiid/TeiidCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/teiid/TeiidCommandProvider.java
@@ -66,10 +66,8 @@ public class TeiidCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(TeiidImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/translator/TranslatorCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/translator/TranslatorCommandProvider.java
@@ -66,10 +66,8 @@ public class TranslatorCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(TranslatorImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/userdefinedfunction/UserDefinedFunctionCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/userdefinedfunction/UserDefinedFunctionCommandProvider.java
@@ -70,10 +70,8 @@ public class UserDefinedFunctionCommandProvider implements ShellCommandProvider 
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(UserDefinedFunctionImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) throws KException {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/vdb/VdbCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/vdb/VdbCommandProvider.java
@@ -86,10 +86,8 @@ public class VdbCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(VdbImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/vdbimport/VdbImportCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/vdbimport/VdbImportCommandProvider.java
@@ -66,10 +66,8 @@ public class VdbImportCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(VdbImportImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/view/ViewCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/view/ViewCommandProvider.java
@@ -70,10 +70,8 @@ public class ViewCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(ViewImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/commands/virtualprocedure/VirtualProcedureCommandProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/commands/virtualprocedure/VirtualProcedureCommandProvider.java
@@ -70,10 +70,8 @@ public class VirtualProcedureCommandProvider implements ShellCommandProvider {
      *      org.komodo.spi.repository.KomodoObject)
      */
     @Override
-    public boolean isRoot ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        if(VirtualProcedureImpl.RESOLVER.resolvable(uow, kObj)) {
-            return false;
-        }
+    public boolean isRoot ( final Repository.UnitOfWork uow,
+                            final KomodoObject kObj ) {
         return false;
     }
 

--- a/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
@@ -60,7 +60,6 @@ public class Messages implements StringConstants {
         LOCAL_REPOSITORY_STARTING,
         LOCAL_REPOSITORY_TIMEOUT_ERROR,
     	COMMAND_NOT_FOUND,
-    	GOOD_BYE,
     	Help_COMMAND_LIST_MSG,
     	Help_INVALID_COMMAND,
     	Help_USAGE,
@@ -161,6 +160,24 @@ public class Messages implements StringConstants {
 //            return getEnumName(this) + DOT + name();
 //        }
 //    }
+
+    public enum ExitCommand {
+
+        EXIT_CANCELED,
+        GOOD_BYE,
+        INVALID_EXIT_ARG;
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see java.lang.Enum#toString()
+         */
+        @Override
+        public String toString() {
+            return getEnumName( this ) + DOT + name();
+        }
+
+    }
 
     public enum StatusCommand {
         Separator,
@@ -345,6 +362,22 @@ public class Messages implements StringConstants {
 //            return getEnumName(this) + DOT + name();
 //        }
 //    }
+
+    public enum SetAutoCommitCommand {
+
+        ENABLE_FLAG_MISSING;
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see java.lang.Enum#toString()
+         */
+        @Override
+        public String toString() {
+            return getEnumName( this ) + DOT + name();
+        }
+
+    }
 
     public enum ShowPropertyCommand {
         InvalidArgMsg_PropertyName;

--- a/plugins/org.komodo.shell/src/org/komodo/shell/ShellCommandFactory.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/ShellCommandFactory.java
@@ -18,6 +18,7 @@ package org.komodo.shell;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
@@ -38,11 +39,14 @@ import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
 import org.komodo.shell.api.WorkspaceStatus;
 import org.komodo.shell.commands.CdCommand;
+import org.komodo.shell.commands.CommitCommand;
 import org.komodo.shell.commands.ExitCommand;
 import org.komodo.shell.commands.HelpCommand;
 import org.komodo.shell.commands.HomeCommand;
 import org.komodo.shell.commands.ListCommand;
 import org.komodo.shell.commands.PlayCommand;
+import org.komodo.shell.commands.RollbackCommand;
+import org.komodo.shell.commands.SetAutoCommitCommand;
 import org.komodo.shell.commands.SetGlobalPropertyCommand;
 import org.komodo.shell.commands.SetPropertyCommand;
 import org.komodo.shell.commands.SetRecordCommand;
@@ -106,13 +110,16 @@ public class ShellCommandFactory {
 
         // register built-in commands
         registerCommand( BUILT_IN_PROVIDER_ID, CdCommand.class, wsStatus );
+        registerCommand( BUILT_IN_PROVIDER_ID, CommitCommand.class, wsStatus );
         registerCommand( BUILT_IN_PROVIDER_ID, ExitCommand.class, wsStatus );
         registerCommand( BUILT_IN_PROVIDER_ID, HelpCommand.class, wsStatus );
         registerCommand( BUILT_IN_PROVIDER_ID, HomeCommand.class, wsStatus );
         registerCommand( BUILT_IN_PROVIDER_ID, ListCommand.class, wsStatus );
         registerCommand( BUILT_IN_PROVIDER_ID, PlayCommand.class, wsStatus );
+        registerCommand( BUILT_IN_PROVIDER_ID, RollbackCommand.class, wsStatus );
         registerCommand( BUILT_IN_PROVIDER_ID, ShowChildrenCommand.class, wsStatus );
         registerCommand( BUILT_IN_PROVIDER_ID, ShowGlobalCommand.class, wsStatus );
+        registerCommand( BUILT_IN_PROVIDER_ID, SetAutoCommitCommand.class, wsStatus );
         registerCommand( BUILT_IN_PROVIDER_ID, SetGlobalPropertyCommand.class, wsStatus );
         registerCommand( BUILT_IN_PROVIDER_ID, SetPropertyCommand.class, wsStatus );
         registerCommand( BUILT_IN_PROVIDER_ID, SetRecordCommand.class, wsStatus );
@@ -188,7 +195,9 @@ public class ShellCommandFactory {
         // load the commands.
         for (ClassLoader classLoader : commandClassloaders) {
             for (ShellCommandProvider provider : ServiceLoader.load(ShellCommandProvider.class, classLoader)) {
-                providers.add(provider);
+                if ( !Modifier.isAbstract( provider.getClass().getModifiers() ) ) {
+                    providers.add( provider );
+                }
             }
         }
     }

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/CommitCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/CommitCommand.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
+package org.komodo.shell.commands;
+
+import static org.komodo.shell.Messages.SHELL.CommandFailure;
+import static org.komodo.shell.Messages.SetGlobalPropertyCommand.GlobalPropertySet;
+import java.util.List;
+import org.komodo.shell.BuiltInShellCommand;
+import org.komodo.shell.CommandResultImpl;
+import org.komodo.shell.Messages;
+import org.komodo.shell.api.CommandResult;
+import org.komodo.shell.api.WorkspaceStatus;
+
+/**
+ * A command that commits the current transaction.
+ */
+public class CommitCommand extends BuiltInShellCommand {
+
+    /**
+     * The command name.
+     */
+    public static final String NAME = "commit"; //$NON-NLS-1$
+
+    /**
+     * @param status
+     *        the workspace status (cannot be <code>null</code>)
+     */
+    public CommitCommand( final WorkspaceStatus status ) {
+        super( status, NAME );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#doExecute()
+     */
+    @Override
+    protected CommandResult doExecute() {
+        try {
+            getWorkspaceStatus().commit( CommitCommand.class.getName() );
+            return new CommandResultImpl( Messages.getString( GlobalPropertySet, WorkspaceStatus.AUTO_COMMIT ) );
+        } catch ( final Exception e ) {
+            return new CommandResultImpl( false, Messages.getString( CommandFailure, NAME ), e );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#getMaxArgCount()
+     */
+    @Override
+    protected int getMaxArgCount() {
+        return 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommand#isValidForCurrentContext()
+     */
+    @Override
+    public boolean isValidForCurrentContext() {
+        return !getWorkspaceStatus().isAutoCommit();
+    }
+
+    /**
+     * @see org.komodo.shell.BuiltInShellCommand#tabCompletion(java.lang.String, java.util.List)
+     */
+    @Override
+    public int tabCompletion( final String lastArgument,
+                              final List< CharSequence > candidates ) throws Exception {
+        return -1; // no candidates to add
+    }
+
+}

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/ExitCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/ExitCommand.java
@@ -15,12 +15,20 @@
  */
 package org.komodo.shell.commands;
 
+import static org.komodo.shell.Messages.ExitCommand.EXIT_CANCELED;
+import static org.komodo.shell.Messages.ExitCommand.GOOD_BYE;
+import static org.komodo.shell.Messages.ExitCommand.INVALID_EXIT_ARG;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.komodo.shell.BuiltInShellCommand;
 import org.komodo.shell.CommandResultImpl;
 import org.komodo.shell.Messages;
-import org.komodo.shell.Messages.SHELL;
 import org.komodo.shell.api.CommandResult;
+import org.komodo.shell.api.InvalidCommandArgumentException;
 import org.komodo.shell.api.WorkspaceStatus;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.utils.StringUtils;
 
 /**
  * Implements the 'exit' command.
@@ -36,6 +44,16 @@ public final class ExitCommand extends BuiltInShellCommand {
      * The command name.
      */
     public static final String NAME = "exit"; //$NON-NLS-1$
+
+    private static final List< String > FORCE_ARGS = Arrays.asList( new String[] { "-f", "--force" } ); //$NON-NLS-1$ //$NON-NLS-2$
+    private static final List< String > SAVE_ARGS = Arrays.asList( new String[] { "-s", "--save" } ); //$NON-NLS-1$ //$NON-NLS-2$
+    private static final List< String > VALID_ARGS;
+
+    static {
+        VALID_ARGS = new ArrayList<>(FORCE_ARGS.size() + SAVE_ARGS.size());
+        VALID_ARGS.addAll( FORCE_ARGS );
+        VALID_ARGS.addAll( SAVE_ARGS );
+    }
 
     /**
      * @param wsStatus
@@ -53,12 +71,48 @@ public final class ExitCommand extends BuiltInShellCommand {
     @Override
     protected CommandResult doExecute() {
         try {
-    		getWorkspaceStatus().getShell().exit();
-            return new CommandResultImpl( Messages.getString( SHELL.GOOD_BYE ) );
-        } catch (final Exception e) {
+            final String arg = optionalArgument( 0 );
+            final boolean hasArg = !StringUtils.isBlank( arg );
+
+            // make sure arg is valid
+            if ( hasArg && !VALID_ARGS.contains( arg ) ) {
+                final String errorMsg = Messages.getString( INVALID_EXIT_ARG, arg );
+                return new CommandResultImpl( false, errorMsg, new InvalidCommandArgumentException( 0, errorMsg ) );
+            }
+
+            // max of one argument (this is checked by super)
+            assert( optionalArgument( 1 ) == null );
+
+            boolean force = ( hasArg && FORCE_ARGS.contains( arg ) );
+            boolean save = ( hasArg && SAVE_ARGS.contains( arg ) );
+
+            final WorkspaceStatus wsStatus = getWorkspaceStatus();
+            final UnitOfWork uow = wsStatus.getTransaction();
+            boolean doExit = false;
+
+            if ( uow.hasChanges() ) {
+                if ( force ) {
+                    uow.rollback();
+                    doExit = true;
+                } else if ( save ) {
+                    uow.commit();
+                    doExit = true;
+                }
+            } else {
+                doExit = true;
+            }
+
+            if ( doExit ) {
+                wsStatus.getShell().exit();
+                return new CommandResultImpl( Messages.getString( GOOD_BYE ) );
+            }
+
+            // transaction has unsaved changes and neither save or force quit arg was present
+            return new CommandResultImpl( false, Messages.getString( EXIT_CANCELED ), null );
+        } catch ( final Exception e ) {
             return new CommandResultImpl( false, e.getLocalizedMessage(), e );
         }
-	}
+    }
 
     /**
      * {@inheritDoc}
@@ -67,7 +121,7 @@ public final class ExitCommand extends BuiltInShellCommand {
      */
     @Override
     protected int getMaxArgCount() {
-        return 0;
+        return 1;
     }
 
     /**

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/RollbackCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/RollbackCommand.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
+package org.komodo.shell.commands;
+
+import static org.komodo.shell.Messages.SHELL.CommandFailure;
+import static org.komodo.shell.Messages.SetGlobalPropertyCommand.GlobalPropertySet;
+import java.util.List;
+import org.komodo.shell.BuiltInShellCommand;
+import org.komodo.shell.CommandResultImpl;
+import org.komodo.shell.Messages;
+import org.komodo.shell.api.CommandResult;
+import org.komodo.shell.api.WorkspaceStatus;
+
+/**
+ * A command that rolls back the current transaction.
+ */
+public class RollbackCommand extends BuiltInShellCommand {
+
+    /**
+     * The command name.
+     */
+    public static final String NAME = "rollback"; //$NON-NLS-1$
+
+    /**
+     * @param status
+     *        the workspace status (cannot be <code>null</code>)
+     */
+    public RollbackCommand( final WorkspaceStatus status ) {
+        super( status, NAME );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#doExecute()
+     */
+    @Override
+    protected CommandResult doExecute() {
+        try {
+            getWorkspaceStatus().rollback( RollbackCommand.class.getName() );
+            return new CommandResultImpl( Messages.getString( GlobalPropertySet, WorkspaceStatus.AUTO_COMMIT ) );
+        } catch ( final Exception e ) {
+            return new CommandResultImpl( false, Messages.getString( CommandFailure, NAME ), e );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#getMaxArgCount()
+     */
+    @Override
+    protected int getMaxArgCount() {
+        return 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommand#isValidForCurrentContext()
+     */
+    @Override
+    public boolean isValidForCurrentContext() {
+        return !getWorkspaceStatus().isAutoCommit();
+    }
+
+    /**
+     * @see org.komodo.shell.BuiltInShellCommand#tabCompletion(java.lang.String, java.util.List)
+     */
+    @Override
+    public int tabCompletion( final String lastArgument,
+                              final List< CharSequence > candidates ) throws Exception {
+        return -1; // no candidates to add
+    }
+
+}

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/SetAutoCommitCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/SetAutoCommitCommand.java
@@ -1,0 +1,108 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
+package org.komodo.shell.commands;
+
+import static org.komodo.shell.Messages.SHELL.INVALID_BOOLEAN_GLOBAL_PROPERTY_VALUE;
+import static org.komodo.shell.Messages.SetAutoCommitCommand.ENABLE_FLAG_MISSING;
+import static org.komodo.shell.Messages.SetGlobalPropertyCommand.GlobalPropertySet;
+import java.util.List;
+import org.komodo.shell.BuiltInShellCommand;
+import org.komodo.shell.CommandResultImpl;
+import org.komodo.shell.Messages;
+import org.komodo.shell.Messages.SHELL;
+import org.komodo.shell.api.CommandResult;
+import org.komodo.shell.api.WorkspaceStatus;
+
+/**
+ * A command that can enable or disable the automatic committing of commands.
+ */
+public class SetAutoCommitCommand extends BuiltInShellCommand {
+
+    /**
+     * The command name.
+     */
+    public static final String NAME = "set-auto-commit"; //$NON-NLS-1$
+
+    /**
+     * @param status
+     *        the workspace status (cannot be <code>null</code>)
+     */
+    public SetAutoCommitCommand( final WorkspaceStatus status ) {
+        super( status, NAME );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#doExecute()
+     */
+    @Override
+    protected CommandResult doExecute() {
+        try {
+            final String arg = requiredArgument( 0, Messages.getString( ENABLE_FLAG_MISSING ) );
+
+            // Check for invalid arg
+            if ( !arg.equalsIgnoreCase( Boolean.TRUE.toString() ) && !arg.equalsIgnoreCase( Boolean.FALSE.toString() ) ) {
+                return new CommandResultImpl( false,
+                                              Messages.getString( INVALID_BOOLEAN_GLOBAL_PROPERTY_VALUE,
+                                                                  arg,
+                                                                  WorkspaceStatus.AUTO_COMMIT ),
+                                              null );
+            }
+
+            return new CommandResultImpl( Messages.getString( GlobalPropertySet, WorkspaceStatus.AUTO_COMMIT ) );
+        } catch ( final Exception e ) {
+            return new CommandResultImpl( false, Messages.getString( SHELL.CommandFailure, NAME ), e );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#getMaxArgCount()
+     */
+    @Override
+    protected int getMaxArgCount() {
+        return 1;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommand#isValidForCurrentContext()
+     */
+    @Override
+    public boolean isValidForCurrentContext() {
+        return !getWorkspaceStatus().isAutoCommit();
+    }
+
+    /**
+     * @see org.komodo.shell.BuiltInShellCommand#tabCompletion(java.lang.String, java.util.List)
+     */
+    @Override
+    public int tabCompletion( final String lastArgument,
+                              final List< CharSequence > candidates ) throws Exception {
+        if ( getArguments().size() == 0 ) {
+            if ( lastArgument == null ) {
+                candidates.add( Boolean.TRUE.toString() );
+                candidates.add( Boolean.FALSE.toString() );
+            } else {
+                final String value = lastArgument.toUpperCase();
+
+                if ( Boolean.TRUE.toString().toUpperCase().startsWith( value ) ) {
+                    candidates.add( Boolean.TRUE.toString() );
+                } else if ( Boolean.FALSE.toString().toUpperCase().startsWith( value ) ) {
+                    candidates.add( Boolean.FALSE.toString() );
+                }
+            }
+        }
+
+        return ( candidates.isEmpty() ? -1 : ( toString().length() + 1 ) );
+    }
+
+}

--- a/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
@@ -85,6 +85,9 @@ ExitCommand.examples = \
 \t quit
 ExitCommand.usage = exit 
 ExitCommand.help = exits VDB Builder.
+ExitCommand.EXIT_CANCELED = Exit has been canceled since there are pending changes. Run "help exit" to see command usage options.
+ExitCommand.GOOD_BYE=Good bye!
+ExitCommand.INVALID_EXIT_ARG = "{0}" is not a valid Exit command argument. Run "help exit" to see command usage options.
 
 # ExportCommand
 ExportCommand.examples= \
@@ -414,6 +417,26 @@ ServerCommand.noTeiidInstancesDefined=No teiid instances have been defined in th
 ServerCommand.teiidSetOk=Teiid "{0}" set as current instance.
 ServerCommand.noTeiidWithName=No teiid instance found that matches the name or id: {0}
 
+# SetAutoCommitCommand
+SetAutoCommitCommand.examples = \
+\t set-auto-commit true \n \
+\t set-auto-commit false
+SetAutoCommitCommand.usage = set-auto-commit <true | false>
+SetAutoCommitCommand.help = set the property value for the shell's auto-commit state.
+SetAutoCommitCommand.ENABLE_FLAG_MISSING = Please specify either "true" or "false" as the new auto-commit value.
+
+# CommitCommand
+CommitCommand.examples = \
+\t commit
+CommitCommand.usage = commit
+CommitCommand.help = commits the current transaction. Only available when auto-commit is set to "false."
+
+# RollbackCommand
+RollbackCommand.examples = \
+\t rollback
+RollbackCommand.usage = rollback
+RollbackCommand.help = rollbacks the current transaction (all unsaved changes are lost). Only available when auto-commit is set to "false."
+
 # This message have SHELL enum definitions in Messages
 SHELL.ERROR_LOADING_PROPERTIES = Error loading startup properties "{0}": {1} 
 SHELL.PATH_NOT_FOUND = "** {0} not found **
@@ -435,7 +458,6 @@ SHELL.ENGINE_STARTING=Starting VDB Builder Engine...
 SHELL.LOCAL_REPOSITORY_STARTING=Starting Local Repository initialization ...
 SHELL.LOCAL_REPOSITORY_TIMEOUT_ERROR=Error: Timeout awaiting initialization of local repository
 SHELL.COMMAND_NOT_FOUND=Command not found.  Try "help" for a list of available commands.
-SHELL.GOOD_BYE=Good bye!
 SHELL.Help_COMMAND_LIST_MSG=VDB Builder Shell supports the following commands at this workspace context:\n
 SHELL.Help_INVALID_COMMAND=No help available: "{0}" is not a valid command.
 SHELL.Help_GET_HELP_1=Enter "help" to get a list of available commands or "help <command-name>" for specific information about one command.

--- a/plugins/org.komodo.spi/src/org/komodo/spi/repository/Repository.java
+++ b/plugins/org.komodo.spi/src/org/komodo/spi/repository/Repository.java
@@ -187,6 +187,13 @@ public interface Repository {
         State getState();
 
         /**
+         * @return <code>true</code> if the transaction contains operations that change the state of the repository
+         * @throws KException
+         *         if there is an error determining if there are unsaved changeds
+         */
+        boolean hasChanges() throws KException;
+
+        /**
          * @return <code>true</code> if only rollback is allowed
          */
         boolean isRollbackOnly();


### PR DESCRIPTION
- added WorkspaceSetPropertyCommand and WorkspaceUnsetPropertyCommand- added a Repository.UnitOfWork.hasChanges() method
- added TableConstraintCommandProvider
- changed many of the CommandProvider.isRoot implementations to remove unnecessary check
- ExitCommand now will not exit if the transaction has unsaved changes unless the user enters the command argument to save or abandon changes.
- added SetAutoCommitCommand which sets the auto-commit global property
