### PR TITLE
ShellCommandProvider and ShellCommandFactory API Changes And More

### DIFF
--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/RelationalShellCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/RelationalShellCommand.java
@@ -17,7 +17,6 @@ import org.komodo.shell.api.WorkspaceStatus;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.Repository;
-import org.komodo.spi.repository.Repository.UnitOfWork;
 
 /**
  * A base class for shell command's relating to relational objects.
@@ -61,10 +60,6 @@ public abstract class RelationalShellCommand extends BuiltInShellCommand {
 
     protected Repository getRepository() throws KException {
         return getWorkspaceStatus().getCurrentContext().getRepository();
-    }
-
-    protected UnitOfWork getTransaction() {
-        return getWorkspaceStatus().getTransaction();
     }
 
     protected WorkspaceManager getWorkspaceManager() throws KException {

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/WorkspaceAddChildCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/WorkspaceAddChildCommand.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
+package org.komodo.relational.commands;
+
+import org.komodo.shell.api.CommandResult;
+import org.komodo.shell.api.WorkspaceStatus;
+import org.komodo.shell.commands.AddChildCommand;
+
+/**
+ * A disabled shell command that overrides the default {@link AddChildCommand}. The relatinoal workspace does not
+ * allow custom children.
+ */
+public final class WorkspaceAddChildCommand extends WorkspaceShellCommand {
+
+    static final String NAME = AddChildCommand.NAME; // override
+
+    /**
+     * @param status
+     *        the shell's workspace status (cannot be <code>null</code>)
+     */
+    public WorkspaceAddChildCommand( final WorkspaceStatus status ) {
+        super( status, NAME );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#doExecute()
+     */
+    @Override
+    protected CommandResult doExecute() {
+        assert false;
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#getMaxArgCount()
+     */
+    @Override
+    protected int getMaxArgCount() {
+        return 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#isEnabled()
+     */
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+
+}

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/WorkspaceCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/WorkspaceCommandProvider.java
@@ -7,8 +7,8 @@
  */
 package org.komodo.relational.commands;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -36,22 +36,23 @@ public class WorkspaceCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( CreateSchemaCommand.NAME, CreateSchemaCommand.class );
-        result.put( CreateTeiidCommand.NAME, CreateTeiidCommand.class );
-        result.put( CreateVdbCommand.NAME, CreateVdbCommand.class );
-        result.put( ImportVdbCommand.NAME, ImportVdbCommand.class );
-        result.put( DeleteSchemaCommand.NAME, DeleteSchemaCommand.class );
-        result.put( DeleteTeiidCommand.NAME, DeleteTeiidCommand.class );
-        result.put( DeleteVdbCommand.NAME, DeleteVdbCommand.class );
-        result.put( FindCommand.NAME, FindCommand.class );
-        result.put( SetCustomPropertyCommand.NAME, SetCustomPropertyCommand.class );
-        result.put( UploadVdbCommand.NAME, UploadVdbCommand.class );
-        result.put( UnsetCustomPropertyCommand.NAME, UnsetCustomPropertyCommand.class );
-        result.put( WorkspaceSetPropertyCommand.NAME, WorkspaceSetPropertyCommand.class );
-        result.put( WorkspaceUnsetPropertyCommand.NAME, WorkspaceUnsetPropertyCommand.class );
+        result.add( CreateSchemaCommand.class );
+        result.add( CreateTeiidCommand.class );
+        result.add( CreateVdbCommand.class );
+        result.add( DeleteSchemaCommand.class );
+        result.add( DeleteTeiidCommand.class );
+        result.add( DeleteVdbCommand.class );
+        result.add( FindCommand.class );
+        result.add( ImportVdbCommand.class );
+        result.add( SetCustomPropertyCommand.class );
+        result.add( UploadVdbCommand.class );
+        result.add( UnsetCustomPropertyCommand.class );
+        result.add( WorkspaceAddChildCommand.class );
+        result.add( WorkspaceSetPropertyCommand.class );
+        result.add( WorkspaceUnsetPropertyCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/column/ColumnCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/column/ColumnCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.column;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.model.Column;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,12 +35,12 @@ public class ColumnCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( SetColumnPropertyCommand.NAME, SetColumnPropertyCommand.class );
-        result.put( UnsetColumnPropertyCommand.NAME, UnsetColumnPropertyCommand.class );
-        result.put( RenameChildCommand.NAME, RenameChildCommand.class );
+        result.add( SetColumnPropertyCommand.class );
+        result.add( UnsetColumnPropertyCommand.class );
+        result.add( RenameChildCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/condition/ConditionCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/condition/ConditionCommandProvider.java
@@ -7,9 +7,8 @@
 */
 package org.komodo.relational.commands.condition;
 
-import java.util.HashMap;
-import java.util.Map;
-import org.komodo.relational.commands.condition.RenameChildCommand;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.vdb.Condition;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -36,12 +35,12 @@ public class ConditionCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( SetConditionPropertyCommand.NAME, SetConditionPropertyCommand.class );
-        result.put( UnsetConditionPropertyCommand.NAME, UnsetConditionPropertyCommand.class );
-        result.put( RenameChildCommand.NAME, RenameChildCommand.class );
+        result.add( SetConditionPropertyCommand.class );
+        result.add( UnsetConditionPropertyCommand.class );
+        result.add( RenameChildCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/datarole/DataRoleCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/datarole/DataRoleCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.datarole;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.vdb.DataRole;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,15 +35,15 @@ public class DataRoleCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( AddMappedRoleCommand.NAME, AddMappedRoleCommand.class );
-        result.put( AddPermissionCommand.NAME, AddPermissionCommand.class );
-        result.put( DeleteMappedRoleCommand.NAME, DeleteMappedRoleCommand.class );
-        result.put( DeletePermissionCommand.NAME, DeletePermissionCommand.class );
-        result.put( SetDataRolePropertyCommand.NAME, SetDataRolePropertyCommand.class );
-        result.put( UnsetDataRolePropertyCommand.NAME, UnsetDataRolePropertyCommand.class );
+        result.add( AddMappedRoleCommand.class );
+        result.add( AddPermissionCommand.class );
+        result.add( DeleteMappedRoleCommand.class );
+        result.add( DeletePermissionCommand.class );
+        result.add( SetDataRolePropertyCommand.class );
+        result.add( UnsetDataRolePropertyCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/datatyperesultset/DataTypeResultSetCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/datatyperesultset/DataTypeResultSetCommandProvider.java
@@ -7,9 +7,8 @@
 */
 package org.komodo.relational.commands.datatyperesultset;
 
-import java.util.HashMap;
-import java.util.Map;
-import org.komodo.relational.commands.datatyperesultset.RenameChildCommand;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.model.DataTypeResultSet;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -36,12 +35,12 @@ public class DataTypeResultSetCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( SetDataTypeResultSetPropertyCommand.NAME, SetDataTypeResultSetPropertyCommand.class );
-        result.put( UnsetDataTypeResultSetPropertyCommand.NAME, UnsetDataTypeResultSetPropertyCommand.class );
-        result.put( RenameChildCommand.NAME, RenameChildCommand.class );
+        result.add( SetDataTypeResultSetPropertyCommand.class );
+        result.add( UnsetDataTypeResultSetPropertyCommand.class );
+        result.add( RenameChildCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/entry/EntryCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/entry/EntryCommandProvider.java
@@ -7,9 +7,8 @@
 */
 package org.komodo.relational.commands.entry;
 
-import java.util.HashMap;
-import java.util.Map;
-import org.komodo.relational.commands.entry.RenameChildCommand;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.vdb.Entry;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -36,12 +35,12 @@ public class EntryCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( SetEntryPropertyCommand.NAME, SetEntryPropertyCommand.class );
-        result.put( UnsetEntryPropertyCommand.NAME, UnsetEntryPropertyCommand.class );
-        result.put( RenameChildCommand.NAME, RenameChildCommand.class );
+        result.add( SetEntryPropertyCommand.class );
+        result.add( UnsetEntryPropertyCommand.class );
+        result.add( RenameChildCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/foreignkey/AddReferenceColumnCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/foreignkey/AddReferenceColumnCommand.java
@@ -62,18 +62,17 @@ public final class AddReferenceColumnCommand extends ForeignKeyShellCommand {
                 final ForeignKey foreignKey = getForeignKey();
 
                 // must NOT be a column in the parent of the table constraint
-                final Repository.UnitOfWork transaction = getWorkspaceStatus().getTransaction();
-                final KomodoObject parentTable = foreignKey.getParent( transaction );
+                final KomodoObject parentTable = foreignKey.getParent( getTransaction() );
 
-                if ( parentTable.equals( column.getParent( transaction ) ) ) {
+                if ( parentTable.equals( column.getParent( getTransaction() ) ) ) {
                     result = new CommandResultImpl( false,
                                                     getMessage( INVALID_COLUMN,
                                                                 getWorkspaceStatus().getLabelProvider()
                                                                                     .getDisplayPath( column.getAbsolutePath() ),
-                                                                foreignKey.getName( transaction ) ),
+                                                                foreignKey.getName( getTransaction() ) ),
                                                     null );
                 } else {
-                    foreignKey.addReferencesColumn( transaction, ( Column )column );
+                    foreignKey.addReferencesColumn( getTransaction(), ( Column )column );
                     result = new CommandResultImpl( getMessage( COLUMN_REF_ADDED, columnPath, getContext().getAbsolutePath() ) );
                 }
             } else {

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/foreignkey/DeleteReferenceColumnCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/foreignkey/DeleteReferenceColumnCommand.java
@@ -61,7 +61,7 @@ public final class DeleteReferenceColumnCommand extends ForeignKeyShellCommand {
 
                 if ( column instanceof Column ) {
                     final ForeignKey foreignKey = getForeignKey();
-                    foreignKey.removeReferencesColumn( getWorkspaceStatus().getTransaction(), ( Column )column );
+                    foreignKey.removeReferencesColumn( getTransaction(), ( Column )column );
 
                     result = new CommandResultImpl( getMessage( COLUMN_REMOVED, columnPathArg, getContext().getAbsolutePath() ) );
                 } else {
@@ -95,7 +95,7 @@ public final class DeleteReferenceColumnCommand extends ForeignKeyShellCommand {
                               final List< CharSequence > candidates ) throws Exception {
         if ( getArguments().isEmpty() ) {
             final ForeignKey foreignKey = getForeignKey();
-            final Column[] refCols = foreignKey.getReferencesColumns( getWorkspaceStatus().getTransaction() );
+            final Column[] refCols = foreignKey.getReferencesColumns( getTransaction() );
 
             // no tab-completion if no columns to remove
             if ( refCols.length == 0 ) {

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/foreignkey/ForeignKeyCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/foreignkey/ForeignKeyCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.foreignkey;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.model.ForeignKey;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,11 +35,11 @@ public class ForeignKeyCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( AddReferenceColumnCommand.NAME, AddReferenceColumnCommand.class );
-        result.put( DeleteReferenceColumnCommand.NAME, DeleteReferenceColumnCommand.class );
+        result.add( AddReferenceColumnCommand.class );
+        result.add( DeleteReferenceColumnCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/index/IndexCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/index/IndexCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.index;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.model.Index;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,11 +35,11 @@ public class IndexCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( SetIndexPropertyCommand.NAME, SetIndexPropertyCommand.class );
-        result.put( UnsetIndexPropertyCommand.NAME, UnsetIndexPropertyCommand.class );
+        result.add( SetIndexPropertyCommand.class );
+        result.add( UnsetIndexPropertyCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/mask/MaskCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/mask/MaskCommandProvider.java
@@ -7,9 +7,8 @@
 */
 package org.komodo.relational.commands.mask;
 
-import java.util.HashMap;
-import java.util.Map;
-import org.komodo.relational.commands.mask.RenameChildCommand;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.vdb.Mask;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -36,12 +35,12 @@ public class MaskCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( SetMaskPropertyCommand.NAME, SetMaskPropertyCommand.class );
-        result.put( UnsetMaskPropertyCommand.NAME, UnsetMaskPropertyCommand.class );
-        result.put( RenameChildCommand.NAME, RenameChildCommand.class );
+        result.add( SetMaskPropertyCommand.class );
+        result.add( UnsetMaskPropertyCommand.class );
+        result.add( RenameChildCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ImportCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ImportCommand.java
@@ -89,7 +89,7 @@ public final class ImportCommand extends ModelShellCommand {
             }
 
             // Setup the import
-            importDdl(getWorkspaceStatus().getTransaction(), ddlFile, tempSchema, importOptions, importMessages);
+            importDdl(getTransaction(), ddlFile, tempSchema, importOptions, importMessages);
 
             if(!importMessages.hasError()) {
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ModelCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ModelCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.model;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.model.Model;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,29 +35,29 @@ public class ModelCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( AddPushdownFunctionCommand.NAME, AddPushdownFunctionCommand.class );
-        result.put( AddSourceCommand.NAME, AddSourceCommand.class );
-        result.put( AddStoredProcedureCommand.NAME, AddStoredProcedureCommand.class );
-        result.put( AddTableCommand.NAME, AddTableCommand.class );
-        result.put( AddUserDefinedFunctionCommand.NAME, AddUserDefinedFunctionCommand.class );
-        result.put( AddViewCommand.NAME, AddViewCommand.class );
-        result.put( AddVirtualProcedureCommand.NAME, AddVirtualProcedureCommand.class );
+        result.add( AddPushdownFunctionCommand.class );
+        result.add( AddSourceCommand.class );
+        result.add( AddStoredProcedureCommand.class );
+        result.add( AddTableCommand.class );
+        result.add( AddUserDefinedFunctionCommand.class );
+        result.add( AddViewCommand.class );
+        result.add( AddVirtualProcedureCommand.class );
 
-        result.put( DeletePushdownFunctionCommand.NAME, DeletePushdownFunctionCommand.class );
-        result.put( DeleteSourceCommand.NAME, DeleteSourceCommand.class );
-        result.put( DeleteStoredProcedureCommand.NAME, DeleteStoredProcedureCommand.class );
-        result.put( DeleteTableCommand.NAME, DeleteTableCommand.class );
-        result.put( DeleteUserDefinedFunctionCommand.NAME, DeleteUserDefinedFunctionCommand.class );
-        result.put( DeleteViewCommand.NAME, DeleteViewCommand.class );
-        result.put( DeleteVirtualProcedureCommand.NAME, DeleteVirtualProcedureCommand.class );
+        result.add( DeletePushdownFunctionCommand.class );
+        result.add( DeleteSourceCommand.class );
+        result.add( DeleteStoredProcedureCommand.class );
+        result.add( DeleteTableCommand.class );
+        result.add( DeleteUserDefinedFunctionCommand.class );
+        result.add( DeleteViewCommand.class );
+        result.add( DeleteVirtualProcedureCommand.class );
 
-        result.put( SetModelPropertyCommand.NAME, SetModelPropertyCommand.class );
-        result.put( UnsetModelPropertyCommand.NAME, UnsetModelPropertyCommand.class );
-        result.put( ExportCommand.NAME, ExportCommand.class );
-        result.put( ImportCommand.NAME, ImportCommand.class );
+        result.add( SetModelPropertyCommand.class );
+        result.add( UnsetModelPropertyCommand.class );
+        result.add( ExportCommand.class );
+        result.add( ImportCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/modelsource/ModelSourceCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/modelsource/ModelSourceCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.modelsource;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.vdb.ModelSource;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,11 +35,11 @@ public class ModelSourceCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( SetModelSourcePropertyCommand.NAME, SetModelSourcePropertyCommand.class );
-        result.put( UnsetModelSourcePropertyCommand.NAME, UnsetModelSourcePropertyCommand.class );
+        result.add( SetModelSourcePropertyCommand.class );
+        result.add( UnsetModelSourcePropertyCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/parameter/ParameterCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/parameter/ParameterCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.parameter;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.model.Parameter;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,11 +35,11 @@ public class ParameterCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( SetParameterPropertyCommand.NAME, SetParameterPropertyCommand.class );
-        result.put( UnsetParameterPropertyCommand.NAME, UnsetParameterPropertyCommand.class );
+        result.add( SetParameterPropertyCommand.class );
+        result.add( UnsetParameterPropertyCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/permission/PermissionCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/permission/PermissionCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.permission;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.vdb.Permission;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,15 +35,15 @@ public class PermissionCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( AddConditionCommand.NAME, AddConditionCommand.class );
-        result.put( AddMaskCommand.NAME, AddMaskCommand.class );
-        result.put( DeleteConditionCommand.NAME, DeleteConditionCommand.class );
-        result.put( DeleteMaskCommand.NAME, DeleteMaskCommand.class );
-        result.put( SetPermissionPropertyCommand.NAME, SetPermissionPropertyCommand.class );
-        result.put( UnsetPermissionPropertyCommand.NAME, UnsetPermissionPropertyCommand.class );
+        result.add( AddConditionCommand.class );
+        result.add( AddMaskCommand.class );
+        result.add( DeleteConditionCommand.class );
+        result.add( DeleteMaskCommand.class );
+        result.add( SetPermissionPropertyCommand.class );
+        result.add( UnsetPermissionPropertyCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/pushdownfunction/PushdownFunctionCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/pushdownfunction/PushdownFunctionCommandProvider.java
@@ -7,10 +7,8 @@
 */
 package org.komodo.relational.commands.pushdownfunction;
 
-import java.util.HashMap;
-import java.util.Map;
-import org.komodo.relational.commands.pushdownfunction.RemoveResultSetCommand;
-import org.komodo.relational.commands.pushdownfunction.SetResultSetCommand;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.model.PushdownFunction;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -37,15 +35,15 @@ public class PushdownFunctionCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( AddParameterCommand.NAME, AddParameterCommand.class );
-        result.put( DeleteParameterCommand.NAME, DeleteParameterCommand.class );
-        result.put( SetResultSetCommand.NAME, SetResultSetCommand.class );
-        result.put( RemoveResultSetCommand.NAME, RemoveResultSetCommand.class );
-        result.put( SetPushdownFunctionPropertyCommand.NAME, SetPushdownFunctionPropertyCommand.class );
-        result.put( UnsetPushdownFunctionPropertyCommand.NAME, UnsetPushdownFunctionPropertyCommand.class );
+        result.add( AddParameterCommand.class );
+        result.add( DeleteParameterCommand.class );
+        result.add( SetResultSetCommand.class );
+        result.add( RemoveResultSetCommand.class );
+        result.add( SetPushdownFunctionPropertyCommand.class );
+        result.add( UnsetPushdownFunctionPropertyCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/resultsetcolumn/ResultSetColumnCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/resultsetcolumn/ResultSetColumnCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.resultsetcolumn;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.model.ResultSetColumn;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,11 +35,11 @@ public class ResultSetColumnCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( SetResultSetColumnPropertyCommand.NAME, SetResultSetColumnPropertyCommand.class );
-        result.put( UnsetResultSetColumnPropertyCommand.NAME, UnsetResultSetColumnPropertyCommand.class );
+        result.add( SetResultSetColumnPropertyCommand.class );
+        result.add( UnsetResultSetColumnPropertyCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/schema/SchemaCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/schema/SchemaCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.schema;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.model.Schema;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,12 +35,12 @@ public class SchemaCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( SetSchemaPropertyCommand.NAME, SetSchemaPropertyCommand.class );
-        result.put( UnsetSchemaPropertyCommand.NAME, UnsetSchemaPropertyCommand.class );
-        result.put( ExportCommand.NAME, ExportCommand.class );
+        result.add( SetSchemaPropertyCommand.class );
+        result.add( UnsetSchemaPropertyCommand.class );
+        result.add( ExportCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerCommandProvider.java
@@ -11,9 +11,9 @@ import static org.komodo.relational.commands.server.ServerCommandMessages.Common
 import static org.komodo.relational.commands.server.ServerCommandMessages.Common.CurrentTeiid;
 import static org.komodo.relational.commands.server.ServerCommandMessages.Common.NotConnected;
 import static org.komodo.relational.commands.server.ServerCommandMessages.Common.serverStatusText;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 import org.komodo.relational.Messages;
 import org.komodo.relational.teiid.Teiid;
 import org.komodo.relational.workspace.WorkspaceManager;
@@ -48,23 +48,23 @@ public class ServerCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( ServerConnectCommand.NAME, ServerConnectCommand.class );
-        result.put( ServerDisconnectCommand.NAME, ServerDisconnectCommand.class );
-        result.put( ServerSetCommand.NAME, ServerSetCommand.class );
-        result.put( ServerShowVdbsCommand.NAME, ServerShowVdbsCommand.class );
-        result.put( ServerShowTranslatorsCommand.NAME, ServerShowTranslatorsCommand.class );
-        result.put( ServerShowDatasourcesCommand.NAME, ServerShowDatasourcesCommand.class );
-        result.put( ServerShowDatasourceTypesCommand.NAME, ServerShowDatasourceTypesCommand.class );
-        result.put( ServerDeployVdbCommand.NAME, ServerDeployVdbCommand.class );
-        result.put( ServerUndeployVdbCommand.NAME, ServerUndeployVdbCommand.class );
-        result.put( ServerImportVdbCommand.NAME, ServerImportVdbCommand.class );
-        result.put( ServerShowVdbCommand.NAME, ServerShowVdbCommand.class );
-        result.put( ServerShowTranslatorCommand.NAME, ServerShowTranslatorCommand.class );
-        result.put( ServerShowDatasourceCommand.NAME, ServerShowDatasourceCommand.class );
-        result.put( ServerShowDatasourceTypeCommand.NAME, ServerShowDatasourceTypeCommand.class );
+        result.add( ServerConnectCommand.class );
+        result.add( ServerDisconnectCommand.class );
+        result.add( ServerSetCommand.class );
+        result.add( ServerShowVdbsCommand.class );
+        result.add( ServerShowTranslatorsCommand.class );
+        result.add( ServerShowDatasourcesCommand.class );
+        result.add( ServerShowDatasourceTypesCommand.class );
+        result.add( ServerDeployVdbCommand.class );
+        result.add( ServerUndeployVdbCommand.class );
+        result.add( ServerImportVdbCommand.class );
+        result.add( ServerShowVdbCommand.class );
+        result.add( ServerShowTranslatorCommand.class );
+        result.add( ServerShowDatasourceCommand.class );
+        result.add( ServerShowDatasourceTypeCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerDisconnectCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerDisconnectCommand.java
@@ -49,11 +49,11 @@ public final class ServerDisconnectCommand extends ServerShellCommand {
 
         try {
             Teiid teiid = getWorkspaceServer();
-            TeiidInstance teiidInstance = teiid.getTeiidInstance( getWorkspaceStatus().getTransaction() );
+            TeiidInstance teiidInstance = teiid.getTeiidInstance( getTransaction() );
 
             if ( teiidInstance.isConnected() ) {
                 print( CompletionConstants.MESSAGE_INDENT,
-                       getMessage( AttemptingToDisconnect, teiid.getName( getWorkspaceStatus().getTransaction() ) ) );
+                       getMessage( AttemptingToDisconnect, teiid.getName( getTransaction() ) ) );
 
                 teiidInstance.disconnect();
                 result = new CommandResultImpl( getMessage( DisconnectSuccessMsg, teiid.getName( getTransaction() ) ) );

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerShellCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerShellCommand.java
@@ -61,14 +61,14 @@ abstract class ServerShellCommand extends RelationalShellCommand {
     protected String getWorkspaceServerName() throws KException {
         KomodoObject server = getWorkspaceServer();
         if(server!=null) {
-            return server.getName(getWorkspaceStatus().getTransaction());
+            return server.getName(getTransaction());
         }
         return null;
     }
 
     protected Teiid getWorkspaceServer() throws KException {
         KomodoObject kObj = getWorkspaceStatus().getStateObjects().get(ServerCommandProvider.SERVER_DEFAULT_KEY);
-        if(kObj!=null && Teiid.RESOLVER.resolvable(getWorkspaceStatus().getTransaction(), kObj)) {
+        if(kObj!=null && Teiid.RESOLVER.resolvable(getTransaction(), kObj)) {
             return (Teiid)kObj;
         }
         return null;

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/storedprocedure/StoredProcedureCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/storedprocedure/StoredProcedureCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.storedprocedure;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.model.StoredProcedure;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,15 +35,15 @@ public class StoredProcedureCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( AddParameterCommand.NAME, AddParameterCommand.class );
-        result.put( DeleteParameterCommand.NAME, DeleteParameterCommand.class );
-        result.put( SetResultSetCommand.NAME, SetResultSetCommand.class );
-        result.put( RemoveResultSetCommand.NAME, RemoveResultSetCommand.class );
-        result.put( SetStoredProcedurePropertyCommand.NAME, SetStoredProcedurePropertyCommand.class );
-        result.put( UnsetStoredProcedurePropertyCommand.NAME, UnsetStoredProcedurePropertyCommand.class );
+        result.add( AddParameterCommand.class );
+        result.add( DeleteParameterCommand.class );
+        result.add( SetResultSetCommand.class );
+        result.add( RemoveResultSetCommand.class );
+        result.add( SetStoredProcedurePropertyCommand.class );
+        result.add( UnsetStoredProcedurePropertyCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/TableCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/TableCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.table;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.model.Table;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,23 +35,23 @@ public class TableCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( AddAccessPatternCommand.NAME, AddAccessPatternCommand.class );
-        result.put( AddColumnCommand.NAME, AddColumnCommand.class );
-        result.put( AddForeignKeyCommand.NAME, AddForeignKeyCommand.class );
-        result.put( AddIndexCommand.NAME, AddIndexCommand.class );
-        result.put( AddUniqueConstraintCommand.NAME, AddUniqueConstraintCommand.class );
+        result.add( AddAccessPatternCommand.class );
+        result.add( AddColumnCommand.class );
+        result.add( AddForeignKeyCommand.class );
+        result.add( AddIndexCommand.class );
+        result.add( AddUniqueConstraintCommand.class );
 
-        result.put( DeleteAccessPatternCommand.NAME, DeleteAccessPatternCommand.class );
-        result.put( DeleteColumnCommand.NAME, DeleteColumnCommand.class );
-        result.put( DeleteForeignKeyCommand.NAME, DeleteForeignKeyCommand.class );
-        result.put( DeleteIndexCommand.NAME, DeleteIndexCommand.class );
-        result.put( DeleteUniqueConstraintCommand.NAME, DeleteUniqueConstraintCommand.class );
+        result.add( DeleteAccessPatternCommand.class );
+        result.add( DeleteColumnCommand.class );
+        result.add( DeleteForeignKeyCommand.class );
+        result.add( DeleteIndexCommand.class );
+        result.add( DeleteUniqueConstraintCommand.class );
 
-        result.put( SetTablePropertyCommand.NAME, SetTablePropertyCommand.class );
-        result.put( UnsetTablePropertyCommand.NAME, UnsetTablePropertyCommand.class );
+        result.add( SetTablePropertyCommand.class );
+        result.add( UnsetTablePropertyCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tableconstraint/AddConstraintColumnCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tableconstraint/AddConstraintColumnCommand.java
@@ -62,18 +62,17 @@ public final class AddConstraintColumnCommand extends TableConstraintShellComman
                 final TableConstraint constraint = getTableConstraint();
 
                 // must be a column in the parent of the table constraint
-                final Repository.UnitOfWork transaction = getWorkspaceStatus().getTransaction();
-                final KomodoObject parentTable = constraint.getParent( transaction );
+                final KomodoObject parentTable = constraint.getParent( getTransaction() );
 
-                if ( parentTable.equals( column.getParent( transaction ) ) ) {
-                    constraint.addColumn( transaction, ( Column )column );
+                if ( parentTable.equals( column.getParent( getTransaction() ) ) ) {
+                    constraint.addColumn( getTransaction(), ( Column )column );
                     result = new CommandResultImpl( getMessage( COLUMN_REF_ADDED, columnPath, getContext().getAbsolutePath() ) );
                 } else {
                     result = new CommandResultImpl( false,
                                                     getMessage( INVALID_COLUMN,
                                                                 getWorkspaceStatus().getLabelProvider()
                                                                                     .getDisplayPath( column.getAbsolutePath() ),
-                                                                constraint.getName( transaction ) ),
+                                                                constraint.getName( getTransaction() ) ),
                                                     null );
                 }
             } else {

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tableconstraint/DeleteConstraintColumnCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tableconstraint/DeleteConstraintColumnCommand.java
@@ -61,7 +61,7 @@ public final class DeleteConstraintColumnCommand extends TableConstraintShellCom
 
                 if ( column instanceof Column ) {
                     final TableConstraint constraint = getTableConstraint();
-                    constraint.removeColumn( getWorkspaceStatus().getTransaction(), ( Column )column );
+                    constraint.removeColumn( getTransaction(), ( Column )column );
 
                     result = new CommandResultImpl( getMessage( COLUMN_REMOVED,
                                                                 columnPathArg,
@@ -97,7 +97,7 @@ public final class DeleteConstraintColumnCommand extends TableConstraintShellCom
                               final List< CharSequence > candidates ) throws Exception {
         if ( getArguments().isEmpty() ) {
             final TableConstraint constraint = getTableConstraint();
-            final Column[] refCols = constraint.getColumns( getWorkspaceStatus().getTransaction() );
+            final Column[] refCols = constraint.getColumns( getTransaction() );
 
             // no tab-completion if no columns to remove
             if ( refCols.length == 0 ) {

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tableconstraint/TableConstraintCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tableconstraint/TableConstraintCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.tableconstraint;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.model.AccessPattern;
 import org.komodo.relational.model.ForeignKey;
 import org.komodo.relational.model.Index;
@@ -75,11 +75,11 @@ public class TableConstraintCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand > > provideCommands() {
-        final Map< String, Class< ? extends ShellCommand > > result = new HashMap< >();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( AddConstraintColumnCommand.NAME, AddConstraintColumnCommand.class );
-        result.put( DeleteConstraintColumnCommand.NAME, DeleteConstraintColumnCommand.class );
+        result.add( AddConstraintColumnCommand.class );
+        result.add( DeleteConstraintColumnCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tabularresultset/TabularResultSetCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tabularresultset/TabularResultSetCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.tabularresultset;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.model.TabularResultSet;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,11 +35,11 @@ public class TabularResultSetCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( AddColumnCommand.NAME, AddColumnCommand.class );
-        result.put( DeleteColumnCommand.NAME, DeleteColumnCommand.class );
+        result.add( AddColumnCommand.class );
+        result.add( DeleteColumnCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/teiid/TeiidCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/teiid/TeiidCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.teiid;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.teiid.Teiid;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,11 +35,11 @@ public class TeiidCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( SetTeiidPropertyCommand.NAME, SetTeiidPropertyCommand.class );
-        result.put( UnsetTeiidPropertyCommand.NAME, UnsetTeiidPropertyCommand.class );
+        result.add( SetTeiidPropertyCommand.class );
+        result.add( UnsetTeiidPropertyCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/translator/TranslatorCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/translator/TranslatorCommandProvider.java
@@ -7,9 +7,8 @@
 */
 package org.komodo.relational.commands.translator;
 
-import java.util.HashMap;
-import java.util.Map;
-import org.komodo.relational.commands.translator.RenameChildCommand;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.vdb.Translator;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -36,12 +35,12 @@ public class TranslatorCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( SetTranslatorPropertyCommand.NAME, SetTranslatorPropertyCommand.class );
-        result.put( UnsetTranslatorPropertyCommand.NAME, UnsetTranslatorPropertyCommand.class );
-        result.put( RenameChildCommand.NAME, RenameChildCommand.class );
+        result.add( SetTranslatorPropertyCommand.class );
+        result.add( UnsetTranslatorPropertyCommand.class );
+        result.add( RenameChildCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/userdefinedfunction/UserDefinedFunctionCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/userdefinedfunction/UserDefinedFunctionCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.userdefinedfunction;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.model.UserDefinedFunction;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,13 +35,13 @@ public class UserDefinedFunctionCommandProvider implements ShellCommandProvider 
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( AddParameterCommand.NAME, AddParameterCommand.class );
-        result.put( DeleteParameterCommand.NAME, DeleteParameterCommand.class );
-        result.put( SetUserDefinedFunctionPropertyCommand.NAME, SetUserDefinedFunctionPropertyCommand.class );
-        result.put( UnsetUserDefinedFunctionPropertyCommand.NAME, UnsetUserDefinedFunctionPropertyCommand.class );
+        result.add( AddParameterCommand.class );
+        result.add( DeleteParameterCommand.class );
+        result.add( SetUserDefinedFunctionPropertyCommand.class );
+        result.add( UnsetUserDefinedFunctionPropertyCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/VdbCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/VdbCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.vdb;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,33 +35,33 @@ public class VdbCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( AddDataRoleCommand.NAME, AddDataRoleCommand.class );
-        result.put( AddEntryCommand.NAME, AddEntryCommand.class );
-        result.put( AddImportCommand.NAME, AddImportCommand.class );
-        result.put( AddModelCommand.NAME, AddModelCommand.class );
-        result.put( AddTranslatorCommand.NAME, AddTranslatorCommand.class );
+        result.add( AddDataRoleCommand.class );
+        result.add( AddEntryCommand.class );
+        result.add( AddImportCommand.class );
+        result.add( AddModelCommand.class );
+        result.add( AddTranslatorCommand.class );
 
-        result.put( DeleteDataRoleCommand.NAME, DeleteDataRoleCommand.class );
-        result.put( DeleteEntryCommand.NAME, DeleteEntryCommand.class );
-        result.put( DeleteImportCommand.NAME, DeleteImportCommand.class );
-        result.put( DeleteModelCommand.NAME, DeleteModelCommand.class );
-        result.put( DeleteTranslatorCommand.NAME, DeleteTranslatorCommand.class );
+        result.add( DeleteDataRoleCommand.class );
+        result.add( DeleteEntryCommand.class );
+        result.add( DeleteImportCommand.class );
+        result.add( DeleteModelCommand.class );
+        result.add( DeleteTranslatorCommand.class );
 
-        result.put( ShowDataRolesCommand.NAME, ShowDataRolesCommand.class );
-        result.put( ShowEntriesCommand.NAME, ShowEntriesCommand.class );
-        result.put( ShowImportsCommand.NAME, ShowImportsCommand.class );
-        result.put( ShowModelsCommand.NAME, ShowModelsCommand.class );
-        result.put( ShowTranslatorsCommand.NAME, ShowTranslatorsCommand.class );
+        result.add( ShowDataRolesCommand.class );
+        result.add( ShowEntriesCommand.class );
+        result.add( ShowImportsCommand.class );
+        result.add( ShowModelsCommand.class );
+        result.add( ShowTranslatorsCommand.class );
 
-        result.put( ShowVdbCommand.NAME, ShowVdbCommand.class );
-        result.put( SetVdbPropertyCommand.NAME, SetVdbPropertyCommand.class );
-        result.put( ExportCommand.NAME, ExportCommand.class );
-        result.put( UnsetVdbPropertyCommand.NAME, UnsetVdbPropertyCommand.class );
-        
-        result.put( UploadModelCommand.NAME, UploadModelCommand.class );
+        result.add( ShowVdbCommand.class );
+        result.add( SetVdbPropertyCommand.class );
+        result.add( ExportCommand.class );
+        result.add( UnsetVdbPropertyCommand.class );
+
+        result.add( UploadModelCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdbimport/VdbImportCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdbimport/VdbImportCommandProvider.java
@@ -7,9 +7,8 @@
 */
 package org.komodo.relational.commands.vdbimport;
 
-import java.util.HashMap;
-import java.util.Map;
-import org.komodo.relational.commands.vdbimport.RenameChildCommand;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.vdb.VdbImport;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -36,12 +35,12 @@ public class VdbImportCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( SetVdbImportPropertyCommand.NAME, SetVdbImportPropertyCommand.class );
-        result.put( UnsetVdbImportPropertyCommand.NAME, UnsetVdbImportPropertyCommand.class );
-        result.put( RenameChildCommand.NAME, RenameChildCommand.class );
+        result.add( SetVdbImportPropertyCommand.class );
+        result.add( UnsetVdbImportPropertyCommand.class );
+        result.add( RenameChildCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/view/ViewCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/view/ViewCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.view;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.model.View;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,13 +35,13 @@ public class ViewCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( AddColumnCommand.NAME, AddColumnCommand.class );
-        result.put( DeleteColumnCommand.NAME, DeleteColumnCommand.class );
-        result.put( SetViewPropertyCommand.NAME, SetViewPropertyCommand.class );
-        result.put( UnsetViewPropertyCommand.NAME, UnsetViewPropertyCommand.class );
+        result.add( AddColumnCommand.class );
+        result.add( DeleteColumnCommand.class );
+        result.add( SetViewPropertyCommand.class );
+        result.add( UnsetViewPropertyCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/virtualprocedure/VirtualProcedureCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/virtualprocedure/VirtualProcedureCommandProvider.java
@@ -7,8 +7,8 @@
 */
 package org.komodo.relational.commands.virtualprocedure;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import org.komodo.relational.model.VirtualProcedure;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
@@ -35,13 +35,13 @@ public class VirtualProcedureCommandProvider implements ShellCommandProvider {
      * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
      */
     @Override
-    public Map< String, Class< ? extends ShellCommand >> provideCommands() {
-        final Map< String, Class< ? extends ShellCommand >> result = new HashMap<>();
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
 
-        result.put( AddParameterCommand.NAME, AddParameterCommand.class );
-        result.put( DeleteParameterCommand.NAME, DeleteParameterCommand.class );
-        result.put( SetVirtualProcedurePropertyCommand.NAME, SetVirtualProcedurePropertyCommand.class );
-        result.put( UnsetVirtualProcedurePropertyCommand.NAME, UnsetVirtualProcedurePropertyCommand.class );
+        result.add( AddParameterCommand.class );
+        result.add( DeleteParameterCommand.class );
+        result.add( SetVirtualProcedurePropertyCommand.class );
+        result.add( UnsetVirtualProcedurePropertyCommand.class );
 
         return result;
     }

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommandFactory.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommandFactory.java
@@ -7,8 +7,7 @@
 */
 package org.komodo.shell.api;
 
-import java.util.Collection;
-import java.util.List;
+import java.util.Set;
 
 /**
  *
@@ -16,35 +15,24 @@ import java.util.List;
 public interface ShellCommandFactory {
 
     /**
-     * @return the command providers (never <code>null</code>)
+     * @return an unmodifiable collection of command providers (never <code>null</code>)
      */
-    Collection<ShellCommandProvider> getCommandProviders();
-    
+    Set< ShellCommandProvider > getCommandProviders();
+
     /**
      * @param commandName
      *        the name of the available command being requested (cannot be empty)
      * @return the specified command or a "command not found" command (never <code>null</code>)
-     * @throws Exception if an error occurs
-     */
-    ShellCommand getCommand( final String commandName ) throws Exception;
-    
-    /**
-     * Get valid command names for the current context.
-     *
-     * @return a list of commands for current context (never <code>null</code>)
-     * @throws Exception
-     *         if error occurs
-     */
-    List< String > getCommandNamesForCurrentContext() throws Exception;
-    
-    /**
-     * Registers all built-in and discovered commands.
-     *
-     * @param wsStatus
-     *        the workspace status (cannot be <code>null</code>)
      * @throws Exception
      *         if an error occurs
      */
-    public void registerCommands( final WorkspaceStatus wsStatus ) throws Exception;
+    ShellCommand getCommand( final String commandName ) throws Exception;
+
+    /**
+     * @return a sorted collection of the valid command names for the current context (never <code>null</code>)
+     * @throws Exception
+     *         if error occurs
+     */
+    Set< String > getCommandNamesForCurrentContext() throws Exception;
 
 }

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommandProvider.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommandProvider.java
@@ -15,7 +15,7 @@
  */
 package org.komodo.shell.api;
 
-import java.util.Map;
+import java.util.Set;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.Repository;
@@ -26,11 +26,12 @@ import org.komodo.spi.repository.Repository;
  */
 public interface ShellCommandProvider {
 
-	/**
-	 * Called to get the collection of commands contributed by the provider.
-	 * @return the map of commands
-	 */
-	public Map<String, Class<? extends ShellCommand>> provideCommands();
+    /**
+     * Called to get the collection of commands contributed by the provider.
+     *
+     * @return the provided commands (can be <code>null</code> or empty)
+     */
+    public Set< Class< ? extends ShellCommand > > provideCommands();
 
     /**
      * Resolve the supplied KomodoObject

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceStatus.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceStatus.java
@@ -250,7 +250,7 @@ public interface WorkspaceStatus extends StringConstants {
      * @return the command factory
      */
     ShellCommandFactory getCommandFactory();
-    
+
     /**
      * @return the komodo engine
      */
@@ -282,6 +282,9 @@ public interface WorkspaceStatus extends StringConstants {
     void rollback( final String source ) throws Exception;
 
     /**
+     * The transaction should <strong>NEVER</strong> be cached by a caller since they can be committed by a command or the shell
+     * framework at any time leaving the cached transaction in a state where it cannot be used.
+     *
      * @return the current transaction (never <code>null</code>)
      */
     UnitOfWork getTransaction();

--- a/plugins/org.komodo.shell/src/org/komodo/shell/BuiltInShellCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/BuiltInShellCommand.java
@@ -31,7 +31,7 @@ import org.komodo.shell.util.KomodoObjectUtils;
 import org.komodo.shell.util.PrintUtils;
 import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.repository.KomodoObject;
-import org.komodo.spi.repository.Repository;
+import org.komodo.spi.repository.Repository.UnitOfWork;
 import org.komodo.utils.ArgCheck;
 import org.komodo.utils.StringUtils;
 
@@ -143,6 +143,10 @@ public abstract class BuiltInShellCommand implements ShellCommand, StringConstan
     @Override
     public final String[] getAliases() {
         return this.aliases;
+    }
+
+    protected UnitOfWork getTransaction() {
+        return getWorkspaceStatus().getTransaction();
     }
 
     @Override
@@ -464,16 +468,15 @@ public abstract class BuiltInShellCommand implements ShellCommand, StringConstan
     	// List of potentials completions
     	List<String> potentialsList = new ArrayList<String>();
     	// Only offer '..' if below the root
-        if ( ( currentContext.getParent( this.wsStatus.getTransaction() ) != null ) && includeGoUp ) {
+        if ( ( currentContext.getParent( getTransaction() ) != null ) && includeGoUp ) {
     		potentialsList.add(StringConstants.DOT_DOT);
     	}
 
-    	Repository.UnitOfWork transaction = getWorkspaceStatus().getTransaction();
     	// --------------------------------------------------------------
     	// No arg - offer children relative current context.
     	// --------------------------------------------------------------
     	if(lastArgument==null) {
-    	    KomodoObject[] children = currentContext.getChildren(transaction);
+    	    KomodoObject[] children = currentContext.getChildren( getTransaction() );
     		for(KomodoObject wsContext : children) {
     		    final String contextName = this.wsStatus.getLabelProvider().getDisplayName( wsContext );
     			potentialsList.add(contextName+FORWARD_SLASH);
@@ -497,7 +500,7 @@ public abstract class BuiltInShellCommand implements ShellCommand, StringConstan
     				KomodoObject deepestMatchingContext = ContextUtils.getDeepestMatchingContextRelative(getWorkspaceStatus(),getWorkspaceStatus().getRootContext(), relativePath);
 
     				// Get children of deepest context match to form potentialsList
-    				KomodoObject[] children = deepestMatchingContext.getChildren(transaction);
+    				KomodoObject[] children = deepestMatchingContext.getChildren( getTransaction() );
     				if(children.length != 0) {
     					// Get all children as potentials
     					for(KomodoObject childContext : children) {
@@ -518,7 +521,7 @@ public abstract class BuiltInShellCommand implements ShellCommand, StringConstan
     		    KomodoObject deepestMatchingContext = ContextUtils.getDeepestMatchingContextRelative(getWorkspaceStatus(), currentContext, lastArgument);
 
     			// Get children of deepest context match to form potentialsList
-    		    KomodoObject[] children = deepestMatchingContext.getChildren(getWorkspaceStatus().getTransaction());
+    		    KomodoObject[] children = deepestMatchingContext.getChildren( getTransaction() );
     			if(children.length!=0) {
     				// Get all children as potentials
     				for(KomodoObject childContext : children) {

--- a/plugins/org.komodo.shell/src/org/komodo/shell/BuiltInShellCommandProvider.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/BuiltInShellCommandProvider.java
@@ -1,0 +1,140 @@
+/*
+ * JBoss, Home of Professional Open Source.
+*
+* See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+*
+* See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+*/
+package org.komodo.shell;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.komodo.repository.ObjectImpl;
+import org.komodo.shell.api.ShellCommand;
+import org.komodo.shell.api.ShellCommandProvider;
+import org.komodo.shell.api.WorkspaceStatus;
+import org.komodo.shell.commands.AddChildCommand;
+import org.komodo.shell.commands.CdCommand;
+import org.komodo.shell.commands.CommitCommand;
+import org.komodo.shell.commands.ExitCommand;
+import org.komodo.shell.commands.HelpCommand;
+import org.komodo.shell.commands.HomeCommand;
+import org.komodo.shell.commands.LibraryCommand;
+import org.komodo.shell.commands.ListCommand;
+import org.komodo.shell.commands.PlayCommand;
+import org.komodo.shell.commands.RenameCommand;
+import org.komodo.shell.commands.RollbackCommand;
+import org.komodo.shell.commands.SetAutoCommitCommand;
+import org.komodo.shell.commands.SetGlobalPropertyCommand;
+import org.komodo.shell.commands.SetPropertyCommand;
+import org.komodo.shell.commands.SetRecordCommand;
+import org.komodo.shell.commands.ShowChildrenCommand;
+import org.komodo.shell.commands.ShowGlobalCommand;
+import org.komodo.shell.commands.ShowPropertiesCommand;
+import org.komodo.shell.commands.ShowPropertyCommand;
+import org.komodo.shell.commands.ShowStatusCommand;
+import org.komodo.shell.commands.ShowSummaryCommand;
+import org.komodo.shell.commands.UnsetPropertyCommand;
+import org.komodo.shell.commands.WorkspaceCommand;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+
+/**
+ * A {@link ShellCommandProvider} for {@link KomodoObject} built-in commands.
+ */
+public final class BuiltInShellCommandProvider implements ShellCommandProvider {
+
+    /**
+     * Constructs a command provider.
+     */
+    public BuiltInShellCommandProvider() {
+        // nothing to do
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      org.komodo.spi.repository.KomodoObject)
+     */
+    @Override
+    public String getStatusMessage( final UnitOfWork transaction,
+                                    final KomodoObject kobject ) {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      org.komodo.spi.repository.KomodoObject)
+     */
+    @Override
+    public String getTypeDisplay( final UnitOfWork transaction,
+                                  final KomodoObject kobject ) {
+        if ( ObjectImpl.class.equals( kobject.getClass() ) ) {
+            return KomodoObject.class.getSimpleName();
+        }
+
+        return kobject.getClass().getSimpleName();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommandProvider#initWorkspaceState(org.komodo.shell.api.WorkspaceStatus)
+     */
+    @Override
+    public void initWorkspaceState( final WorkspaceStatus status ) {
+        // nothing to do
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommandProvider#provideCommands()
+     */
+    @Override
+    public Set< Class< ? extends ShellCommand > > provideCommands() {
+        final Set< Class< ? extends ShellCommand > > result = new HashSet< >();
+
+        result.add( AddChildCommand.class );
+        result.add( CdCommand.class );
+        result.add( CommitCommand.class );
+        result.add( ExitCommand.class );
+        result.add( HelpCommand.class );
+        result.add( HomeCommand.class );
+        result.add( LibraryCommand.class );
+        result.add( ListCommand.class );
+        result.add( PlayCommand.class );
+        result.add( RenameCommand.class );
+        result.add( RollbackCommand.class );
+        result.add( SetAutoCommitCommand.class );
+        result.add( SetGlobalPropertyCommand.class );
+        result.add( SetPropertyCommand.class );
+        result.add( SetRecordCommand.class );
+        result.add( ShowChildrenCommand.class );
+        result.add( ShowGlobalCommand.class );
+        result.add( ShowPropertiesCommand.class );
+        result.add( ShowPropertyCommand.class );
+        result.add( ShowStatusCommand.class );
+        result.add( ShowSummaryCommand.class );
+        result.add( UnsetPropertyCommand.class );
+        result.add( WorkspaceCommand.class );
+
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommandProvider#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      org.komodo.spi.repository.KomodoObject)
+     */
+    @Override
+    public < T extends KomodoObject > T resolve( final UnitOfWork transaction,
+                                                 final KomodoObject kobject ) {
+        return null; // does not resolve any KomodoObject to a subclass type
+    }
+
+}

--- a/plugins/org.komodo.shell/src/org/komodo/shell/DefaultLabelProvider.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/DefaultLabelProvider.java
@@ -199,7 +199,6 @@ public class DefaultLabelProvider implements KomodoObjectLabelProvider {
             return ROOT_PATH;
         }
 
-        final Repository.UnitOfWork uow = this.status.getTransaction();
         KomodoObject kobject = null;
 
         try {
@@ -212,16 +211,16 @@ public class DefaultLabelProvider implements KomodoObjectLabelProvider {
                 }
 
                 if ( this.status.isShowingPropertyNamePrefixes() ) {
-                    if ( parent.hasChild( uow, segment ) ) {
-                        kobject = parent.getChild( uow, segment );
+                    if ( parent.hasChild( this.status.getTransaction(), segment ) ) {
+                        kobject = parent.getChild( this.status.getTransaction(), segment );
                         parent = kobject;
                     } else {
                         return null; // no child with that name
                     }
                 } else {
                     // loop through children and take first one with local name match
-                    for ( final KomodoObject kid : parent.getChildren( uow ) ) {
-                        final String name = kid.getName( uow );
+                    for ( final KomodoObject kid : parent.getChildren( this.status.getTransaction() ) ) {
+                        final String name = kid.getName( this.status.getTransaction() );
                         final int index = name.indexOf( StringConstants.COLON );
 
                         if ( index == -1 ) {

--- a/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
@@ -141,6 +141,23 @@ public class Messages implements StringConstants {
 
     }
 
+    public enum AddChildCommand {
+
+        CHILD_ADDED,
+        MISSING_CHILD_NAME;
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see java.lang.Enum#toString()
+         */
+        @Override
+        public String toString() {
+            return getEnumName( this ) + DOT + name();
+        }
+
+    }
+
     public enum StatusCommand {
         Separator,
         Connected,
@@ -227,8 +244,6 @@ public class Messages implements StringConstants {
     public enum ShowStatusCommand {
         CurrentRepoUrl,
         CurrentRepoName,
-        NoCurrentTeiid,
-        CurrentTeiid,
         CurrentContext;
 
         @Override

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/AddChildCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/AddChildCommand.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
+package org.komodo.shell.commands;
+
+import static org.komodo.shell.Messages.AddChildCommand.CHILD_ADDED;
+import static org.komodo.shell.Messages.AddChildCommand.MISSING_CHILD_NAME;
+import org.komodo.shell.BuiltInShellCommand;
+import org.komodo.shell.CommandResultImpl;
+import org.komodo.shell.Messages;
+import org.komodo.shell.api.CommandResult;
+import org.komodo.shell.api.WorkspaceStatus;
+import org.komodo.shell.util.KomodoObjectUtils;
+import org.komodo.spi.repository.KomodoObject;
+
+/**
+ * Adds a child to a {@link KomodoObject}.
+ * <p>
+ * Usage:
+ * <p>
+ * <code>&nbsp;&nbsp;
+ * add-child &lt;new-child-name&gt; {child-type}
+ * </code>
+ */
+public class AddChildCommand extends BuiltInShellCommand {
+
+    /**
+     * The command name.
+     */
+    public static final String NAME = "add-child"; //$NON-NLS-1$
+
+    /**
+     * @param status
+     *        the workspace status (cannot be <code>null</code>)
+     */
+    public AddChildCommand( final WorkspaceStatus status ) {
+        super( status, NAME );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#doExecute()
+     */
+    @Override
+    protected CommandResult doExecute() {
+        try {
+            final String childNameArg = requiredArgument( 0, Messages.getString( MISSING_CHILD_NAME ) );
+            final String childTypeArg = optionalArgument( 1 );
+
+            final KomodoObject kobject = getContext();
+            kobject.addChild( getTransaction(), childNameArg, childTypeArg );
+            return new CommandResultImpl( Messages.getString( CHILD_ADDED, childNameArg ) );
+        } catch ( final Exception e ) {
+            return new CommandResultImpl( e );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#getMaxArgCount()
+     */
+    @Override
+    protected int getMaxArgCount() {
+        return 2;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommand#isValidForCurrentContext()
+     */
+    @Override
+    public boolean isValidForCurrentContext() {
+        return !KomodoObjectUtils.isRoot( getContext() );
+    }
+
+}

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/ExitCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/ExitCommand.java
@@ -27,7 +27,6 @@ import org.komodo.shell.Messages;
 import org.komodo.shell.api.CommandResult;
 import org.komodo.shell.api.InvalidCommandArgumentException;
 import org.komodo.shell.api.WorkspaceStatus;
-import org.komodo.spi.repository.Repository.UnitOfWork;
 import org.komodo.utils.StringUtils;
 
 /**
@@ -87,10 +86,9 @@ public final class ExitCommand extends BuiltInShellCommand {
             boolean save = ( hasArg && SAVE_ARGS.contains( arg ) );
 
             final WorkspaceStatus wsStatus = getWorkspaceStatus();
-            final UnitOfWork uow = wsStatus.getTransaction();
             boolean doExit = false;
 
-            if ( uow.hasChanges() ) {
+            if ( getTransaction().hasChanges() ) {
                 if ( force ) {
                     wsStatus.rollback( ExitCommand.class.getName() );
                     doExit = true;

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/RenameCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/RenameCommand.java
@@ -93,10 +93,10 @@ public class RenameCommand extends BuiltInShellCommand {
      */
     private boolean validateNotDuplicateType(KomodoObject objToRename, String newName, KomodoObject targetObject) throws Exception {
         boolean hasExistingWithName = false;
-        KomodoObject[] objsOfType = targetObject.getChildrenOfType(getWorkspaceStatus().getTransaction(), objToRename.getTypeIdentifier(getWorkspaceStatus().getTransaction()).getType());
+        KomodoObject[] objsOfType = targetObject.getChildrenOfType(getTransaction(), objToRename.getTypeIdentifier(getTransaction()).getType());
 
         for(KomodoObject kObj : objsOfType) {
-            String kObjName = kObj.getName(getWorkspaceStatus().getTransaction());
+            String kObjName = kObj.getName(getTransaction());
             if(kObjName.equals(newName)) {
                 hasExistingWithName = true;
                 break;
@@ -116,7 +116,7 @@ public class RenameCommand extends BuiltInShellCommand {
         if( origObject != null ) {
         	String parentAbsPath = targetObject.getAbsolutePath();
         	String newChildPath = parentAbsPath + FORWARD_SLASH + newShortName;
-        	origObject.rename(getWorkspaceStatus().getTransaction(), newChildPath);
+        	origObject.rename( getTransaction(), newChildPath );
         } else {
         	throw new Exception(Messages.getString(Messages.RenameCommand.cannotRename_objectDoesNotExist, origObject));
         }
@@ -130,9 +130,9 @@ public class RenameCommand extends BuiltInShellCommand {
         if (getArguments().isEmpty()) {
 			// List of potential completions
 			List<String> potentialsList = new ArrayList<String>();
-			KomodoObject[] children = getWorkspaceStatus().getCurrentContext().getChildren(getWorkspaceStatus().getTransaction());
+			KomodoObject[] children = getWorkspaceStatus().getCurrentContext().getChildren( getTransaction() );
 			for(KomodoObject wsContext : children) {
-				potentialsList.add(wsContext.getName(getWorkspaceStatus().getTransaction()));
+				potentialsList.add(wsContext.getName( getTransaction() ));
 			}
     		// --------------------------------------------------------------
     		// No arg - offer children relative to current context.
@@ -165,7 +165,7 @@ public class RenameCommand extends BuiltInShellCommand {
         KomodoObject context = getContext();
         KomodoObject parent = null;
         try {
-            parent = context.getParent(getWorkspaceStatus().getTransaction());
+            parent = context.getParent( getTransaction() );
         } catch (KException ex) {
             // Exception, parent false
         }

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/SetPropertyCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/SetPropertyCommand.java
@@ -144,16 +144,16 @@ public class SetPropertyCommand extends BuiltInShellCommand {
 
         if ( !StringUtils.isBlank( propValue ) && isMultiValuedProperty( context, propertyName ) ) {
             final String[] values = parseMultiValues( propValue );
-            context.setProperty( getWorkspaceStatus().getTransaction(), propertyName, ( Object[] )values );
+            context.setProperty( getTransaction(), propertyName, ( Object[] )values );
         } else {
-            context.setProperty( getWorkspaceStatus().getTransaction(), propertyName, propValue );
+            context.setProperty( getTransaction(), propertyName, propValue );
         }
     }
 
     private boolean isMultiValuedProperty( final KomodoObject context,
                                            final String name ) throws Exception {
         final String propertyName = isShowingPropertyNamePrefixes() ? name : KomodoObjectUtils.attachPrefix( getWorkspaceStatus(),context, name );
-        final PropertyDescriptor descriptor = context.getPropertyDescriptor( getWorkspaceStatus().getTransaction(),
+        final PropertyDescriptor descriptor = context.getPropertyDescriptor( getTransaction(),
                                                                                             propertyName );
         return ( ( descriptor == null ) ? false : descriptor.isMultiple() );
     }
@@ -164,13 +164,13 @@ public class SetPropertyCommand extends BuiltInShellCommand {
         assert isMultiValuedProperty( context, name );
 
         final String propertyName = isShowingPropertyNamePrefixes() ? name : KomodoObjectUtils.attachPrefix( getWorkspaceStatus(),context, name );
-        final Property property = context.getProperty( getWorkspaceStatus().getTransaction(), propertyName );
-        final Repository.UnitOfWork uow = getWorkspaceStatus().getTransaction();
+        final Property property = context.getProperty( getTransaction(), propertyName );
+        final Repository.UnitOfWork uow = getTransaction();
         final StringBuilder result = new StringBuilder();
         boolean quoted = false;
         boolean firstTime = true;
 
-        for ( final Object value : property.getValues( getWorkspaceStatus().getTransaction() ) ) {
+        for ( final Object value : property.getValues( getTransaction() ) ) {
             if ( !firstTime ) {
                 result.append( ',' );
             } else {
@@ -239,7 +239,7 @@ public class SetPropertyCommand extends BuiltInShellCommand {
             final String propName = isShowingPropertyNamePrefixes() ? propArg : KomodoObjectUtils.attachPrefix( getWorkspaceStatus(),context, propArg );
 
             if ( isMultiValuedProperty( context, propName ) ) {
-                if ( context.hasProperty( getWorkspaceStatus().getTransaction(), propName ) ) {
+                if ( context.hasProperty( getTransaction(), propName ) ) {
                     // concat current multi-values as a string
                     final String value = concatMultiValues( context, propName );
                     candidates.add( value );
@@ -262,9 +262,8 @@ public class SetPropertyCommand extends BuiltInShellCommand {
                                     final String lastArgument,
                                     final List< CharSequence > candidates ) throws Exception {
         final WorkspaceStatus wsStatus = getWorkspaceStatus();
-        final Repository.UnitOfWork uow = wsStatus.getTransaction();
         final String propertyName = isShowingPropertyNamePrefixes() ? name : KomodoObjectUtils.attachPrefix( getWorkspaceStatus(),context, name );
-        final PropertyDescriptor descriptor = context.getPropertyDescriptor( uow, propertyName );
+        final PropertyDescriptor descriptor = context.getPropertyDescriptor( getTransaction(), propertyName );
 
         if ( descriptor == null ) {
             return;

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/UnsetPropertyCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/UnsetPropertyCommand.java
@@ -69,7 +69,7 @@ public class UnsetPropertyCommand extends BuiltInShellCommand {
 
             // remove the property by setting its value to null
             final String propertyName = ( !isShowingPropertyNamePrefixes() ? KomodoObjectUtils.attachPrefix( getWorkspaceStatus(),context, propNameArg ) : propNameArg );
-            context.setProperty( getWorkspaceStatus().getTransaction(),propertyName, (Object[])null );
+            context.setProperty( getTransaction(),propertyName, (Object[])null );
 
             return new CommandResultImpl( getString( "propertyUnset", propNameArg ) ); //$NON-NLS-1$
         } catch ( final Exception e ) {

--- a/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
@@ -1,11 +1,20 @@
 # Generic Messages for command-specific messages 
 # Must use the 'dot' notation below, e.g. <commandName>.usage
 
+# AddChildCommand
+AddChildCommand.examples = \
+\t add-child foo \n \
+\t add-child foo my:type
+AddChildCommand.usage = add-child <child-name> [child-type]
+AddChildCommand.help = \t{0} - adds a child to the current context.
+AddChildCommand.CHILD_ADDED = The child "{0}" was successfully added.
+AddChildCommand.MISSING_CHILD_NAME = A child name is required when adding child.
+
 # CdCommand
 CdCommand.examples= \
 \t cd .. \n \
-\t cd myVdb \n \
-\t cd /myVdb/myDataRole
+\t cd foo \n \
+\t cd /workspace/foo
 CdCommand.usage=cd <path>
 CdCommand.help=\t{0} - change the current workspace context.
 
@@ -54,7 +63,7 @@ ListCommand.noChildrenMsg=There are no children for {0} "{1}".
 
 # PlayCommand
 PlayCommand.examples= \
-\t play /home/vdbuilder_commands/build_my_vdb.txt
+\t play /Users/me/command_files/do_something.txt
 PlayCommand.usage=play <file_name>
 PlayCommand.help=\t{0} - execute commands defined in a specified text file.
 PlayCommand.InvalidArgMsg_FileName=Please specify the command file name.
@@ -64,9 +73,9 @@ PlayCommand.CommandFailure=Failed to execute "{0}"
 
 # RenameCommand
 RenameCommand.examples= \
-\t rename myVdb yourVdb \n \
-\t rename myVdb/myDataRole myVdb/yourDataRole \n \
-\t mv tableNew tableOld
+\t rename foo bar \n \
+\t rename foo/bar foo/widget \n \
+\t mv foo bar
 RenameCommand.usage=rename <object_path> <new_name>
 RenameCommand.help=\t{0} - change the name and/or location of an object.
 RenameCommand.InvalidArgMsg_ObjectName=Please specify the name of the object to rename.
@@ -122,8 +131,6 @@ ShowStatusCommand.usage=show-status
 ShowStatusCommand.help=\t{0} - display current workspace information and status.
 ShowStatusCommand.CurrentRepoUrl= Current Repository Url  : {0}
 ShowStatusCommand.CurrentRepoName=Current Repository Name : {0}
-ShowStatusCommand.NoCurrentTeiid= Current Teiid Instance  : None set
-ShowStatusCommand.CurrentTeiid =  Current Teiid Instance  : {0}
 ShowStatusCommand.CurrentContext =Current Context : [{0}]
 
 # ShowGlobalCommand
@@ -217,18 +224,18 @@ SHELL.TRANSACTION_ROLLBACK_ERROR=An error occurred during the rollback of transa
 SHELL.TRANSACTION_TIMEOUT=Commit of transaction {0} timed out.
 SHELL.COMPONENT_STARTED=Started
 SHELL.COMPONENT_FAILED=Started
-SHELL.ENGINE_STARTING=Starting VDB Builder Engine...
+SHELL.ENGINE_STARTING=Starting engine...
 SHELL.LOCAL_REPOSITORY_STARTING=Starting Local Repository initialization ...
 SHELL.LOCAL_REPOSITORY_TIMEOUT_ERROR=Error: Timeout awaiting initialization of local repository
 SHELL.COMMAND_NOT_FOUND=Command "{0}" not found.  Try "help" for a list of available commands.
-SHELL.Help_COMMAND_LIST_MSG=VDB Builder Shell supports the following commands at this workspace context:\n
+SHELL.Help_COMMAND_LIST_MSG=The following commands are supported at this context:\n
 SHELL.Help_INVALID_COMMAND=No help available: "{0}" is not a valid command.
 SHELL.Help_GET_HELP_1=Enter "help" to get a list of available commands or "help <command-name>" for specific information about one command.
 SHELL.Help_GET_HELP_2=To execute a specific command, try "<command-name> <args>". Also try entering a tab key for command argument completion help.\n
-SHELL.EXITING=Exiting VDB Builder shell due to an error.
+SHELL.EXITING=Exiting due to an error.
 SHELL.INVALID_ARG=Invalid argument:  {0}
 SHELL.USAGE=Usage:
-SHELL.SHUTTING_DOWN=VDB Builder shell shutting down...\n
+SHELL.SHUTTING_DOWN=Shutting down...\n
 SHELL.DONE=done.\n
 SHELL.InvalidArgMsg_EntryPath=An entry path is required.
 SHELL.ENTRY_PATH=  Entry Path

--- a/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoObject.java
+++ b/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoObject.java
@@ -30,8 +30,6 @@ public interface KomodoObject extends KNode {
      *        the name of the new child being added (cannot be empty)
      * @param primaryType
      *        the primary type of the child or <code>null</code> if type is <code>nt:unstructured</code>
-     * @param saveSession
-     *        <code>true</code> if the session should be saved after creating the Komodo object
      * @return the new object (never <code>null</code>)
      * @throws KException
      *         if an error occurs

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/AbstractCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/AbstractCommandTest.java
@@ -216,6 +216,12 @@ public abstract class AbstractCommandTest extends AbstractLocalRepositoryTest {
                 commit();
             } else {
                 rollback();
+
+                if ( result.getError() != null ) {
+                    throw result.getError();
+                }
+
+                Assert.fail( "Failed : " + result.getMessage() ); //$NON-NLS-1$
             }
         } catch ( InvalidCommandArgumentException e ) {
             Assert.fail( "Failed - invalid command: " + e.getMessage() ); //$NON-NLS-1$

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/AllTests.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/AllTests.java
@@ -113,6 +113,9 @@ import org.komodo.relational.commands.virtualprocedure.UnsetVirtualProcedureProp
     SetCustomPropertyCommandTest.class,
     UnsetCustomPropertyCommandTest.class,
     UploadVdbCommandTest.class,
+    WorkspaceAddChildCommandTest.class,
+    WorkspaceSetPropertyCommandTest.class,
+    WorkspaceUnsetPropertyCommandTest.class,
 
     // Column
     SetColumnPropertyCommandTest.class,
@@ -145,7 +148,7 @@ import org.komodo.relational.commands.virtualprocedure.UnsetVirtualProcedureProp
     // Index
     SetIndexPropertyCommandTest.class,
     UnsetIndexPropertyCommandTest.class,
-    
+
     // Mask
     SetMaskPropertyCommandTest.class,
     UnsetMaskPropertyCommandTest.class,
@@ -197,7 +200,7 @@ import org.komodo.relational.commands.virtualprocedure.UnsetVirtualProcedureProp
     // ResultSetColumn
     SetResultSetColumnPropertyCommandTest.class,
     UnsetResultSetColumnPropertyCommandTest.class,
-    
+
     // Schema
     SetSchemaPropertyCommandTest.class,
     UnsetSchemaPropertyCommandTest.class,
@@ -205,7 +208,7 @@ import org.komodo.relational.commands.virtualprocedure.UnsetVirtualProcedureProp
 
     // Server
     ServerSetCommandTest.class,
-    
+
     // StoredProcedure
     org.komodo.relational.commands.storedprocedure.AddParameterCommandTest.class,
     org.komodo.relational.commands.storedprocedure.DeleteParameterCommandTest.class,
@@ -235,7 +238,7 @@ import org.komodo.relational.commands.virtualprocedure.UnsetVirtualProcedureProp
     // TabularResultSet
     org.komodo.relational.commands.tabularresultset.AddColumnCommandTest.class,
     org.komodo.relational.commands.tabularresultset.DeleteColumnCommandTest.class,
-    
+
     // Teiid
     SetTeiidPropertyCommandTest.class,
     UnsetTeiidPropertyCommandTest.class,

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/WorkspaceAddChildCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/WorkspaceAddChildCommandTest.java
@@ -13,30 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.komodo.shell.commands;
+package org.komodo.relational.commands;
 
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
-import org.komodo.shell.AbstractCommandTest;
-import org.komodo.shell.api.CommandResult;
-import org.komodo.shell.util.KomodoObjectUtils;
 
 /**
- * Test Class to test {@link ExitCommand}.
+ * Test Class to test {@link WorkspaceAddChildCommand}.
  */
 @SuppressWarnings( { "javadoc", "nls" } )
-public class ExitCommandTest extends AbstractCommandTest {
+public class WorkspaceAddChildCommandTest extends AbstractCommandTest {
 
-    @Test
-    public void test1() throws Exception {
-        final String[] commands = { "workspace" };
-    	setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
-
-    	// Check WorkspaceContext
-    	assertEquals("/workspace", KomodoObjectUtils.getFullName(wsStatus, wsStatus.getCurrentContext()));
+    @Test( expected = AssertionError.class )
+    public void shouldNotBeAvailableAtWorkspace() throws Exception {
+        final String[] commands = { "workspace",
+                                    "add-child blah" };
+        setup( commands );
+        execute();
     }
 
 }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/WorkspaceSetPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/WorkspaceSetPropertyCommandTest.java
@@ -15,29 +15,20 @@
  */
 package org.komodo.relational.commands;
 
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
-import org.komodo.shell.api.CommandResult;
-import org.komodo.shell.util.KomodoObjectUtils;
 
 /**
- * Test Class to test WorkspaceSetPropertyCommand
- *
+ * Test Class to test {@link WorkspaceSetPropertyCommand}.
  */
 @SuppressWarnings( { "javadoc", "nls" } )
 public class WorkspaceSetPropertyCommandTest extends AbstractCommandTest {
 
-    @Test
-    public void testSetProperty1() throws Exception {
+    @Test( expected = AssertionError.class )
+    public void shouldNotBeAvailableAtWorkspace() throws Exception {
         final String[] commands = { "workspace",
-                                    "create-vdb testVdb1 vdbPath" };
+                                    "set-property blah blah" };
         setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
-
-    	// Check WorkspaceContext
-    	assertEquals("/workspace", KomodoObjectUtils.getFullName(wsStatus, wsStatus.getCurrentContext()));
+        execute();
     }
 
 }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/WorkspaceUnsetPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/WorkspaceUnsetPropertyCommandTest.java
@@ -15,29 +15,20 @@
  */
 package org.komodo.relational.commands;
 
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
-import org.komodo.shell.api.CommandResult;
-import org.komodo.shell.util.KomodoObjectUtils;
 
 /**
- * Test Class to test WorkspaceUnsetPropertyCommand
- *
+ * Test Class to test {@link WorkspaceUnsetPropertyCommand}.
  */
 @SuppressWarnings( { "javadoc", "nls" } )
 public class WorkspaceUnsetPropertyCommandTest extends AbstractCommandTest {
 
-    @Test
-    public void testUnsetProperty1() throws Exception {
+    @Test( expected = AssertionError.class )
+    public void shouldNotBeAvailableAtWorkspace() throws Exception {
         final String[] commands = { "workspace",
-                                    "create-vdb testVdb1 vdbPath" };
+                                    "unset-property blah" };
         setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
-
-    	// Check WorkspaceContext
-    	assertEquals("/workspace", KomodoObjectUtils.getFullName(wsStatus, wsStatus.getCurrentContext()));
+        execute();
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/AbstractCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/AbstractCommandTest.java
@@ -170,6 +170,12 @@ public abstract class AbstractCommandTest extends AbstractLocalRepositoryTest {
                 commit();
             } else {
                 rollback();
+
+                if ( result.getError() != null ) {
+                    throw result.getError();
+                }
+
+                Assert.fail( "Failed : " + result.getMessage() ); //$NON-NLS-1$
             }
         } catch ( InvalidCommandArgumentException e ) {
             Assert.fail( "Failed - invalid command: " + e.getMessage() ); //$NON-NLS-1$

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/AddChildCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/AddChildCommandTest.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+*
+* See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+*
+* See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+*/
+package org.komodo.shell.commands;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import org.komodo.shell.AbstractCommandTest;
+import org.komodo.shell.api.CommandResult;
+import org.komodo.spi.repository.KomodoObject;
+
+/**
+ * Test class for the {@link AddChildCommand}.
+ */
+@SuppressWarnings( { "javadoc", "nls" } )
+public final class AddChildCommandTest extends AbstractCommandTest {
+
+    @Test( expected = AssertionError.class )
+    public void shouldNotAddChildAtRoot() throws Exception {
+        final String[] commands = { "add-child blah" }; // add-child is not available at root
+        setup( commands );
+        execute();
+    }
+
+    @Test
+    public void shouldAddChildAtLibrary() throws Exception {
+        final String childName = "blah";
+        final String[] commands = { "library", "add-child " + childName };
+        setup( commands );
+
+        final CommandResult result = execute();
+        assertThat( result.isOk(), is( true ) );
+
+        final KomodoObject library = _repo.komodoLibrary( getTransaction() );
+        assertThat( library.getChildren( getTransaction() ).length, is( 1 ) );
+        assertThat( library.getChildren( getTransaction() )[ 0 ].getName( getTransaction() ), is( childName ) );
+    }
+
+    @Test
+    public void shouldAddChildAtWorkspace() throws Exception {
+        final String childName = "blah";
+        final String[] commands = { "workspace", "add-child " + childName };
+        setup( commands );
+
+        final CommandResult result = execute();
+        assertThat( result.isOk(), is( true ) );
+
+        final KomodoObject workspace = _repo.komodoWorkspace( getTransaction() );
+        assertThat( workspace.getChildren( getTransaction() ).length, is( 1 ) );
+        assertThat( workspace.getChildren( getTransaction() )[ 0 ].getName( getTransaction() ), is( childName ) );
+    }
+
+}

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/CdCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/CdCommandTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.komodo.shell.AbstractCommandTest;
 import org.komodo.shell.api.CommandResult;
-import org.komodo.shell.commands.CdCommand;
 import org.komodo.shell.util.KomodoObjectUtils;
 
 /**

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/HelpCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/HelpCommandTest.java
@@ -37,7 +37,8 @@ public class HelpCommandTest extends AbstractCommandTest {
 
         // check help text
         String writerOutput = getCommandOutput();
-        assertTrue(writerOutput.contains("VDB Builder Shell supports the following commands at this workspace context"));
+        assertTrue(writerOutput,
+                   writerOutput.contains("The following commands are supported at this context"));
     }
 
     @Test

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/PlayCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/PlayCommandTest.java
@@ -15,10 +15,8 @@
  */
 package org.komodo.shell.commands;
 
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.komodo.shell.AbstractCommandTest;
-import org.komodo.shell.api.CommandResult;
 
 @SuppressWarnings( { "javadoc", "nls" } )
 public final class PlayCommandTest extends AbstractCommandTest {
@@ -71,14 +69,10 @@ public final class PlayCommandTest extends AbstractCommandTest {
 //        }
 //    }
 
-    @Test
+    @Test( expected = AssertionError.class )
     public void shouldFailToPlayNonExistentFile() throws Exception {
         setup( "bogus.txt" );
-        CommandResult result = execute();
-
-        assertEquals(false, result.isOk());
-        String msg = result.getMessage();
-        assertEquals(true, msg.contains("Problem with File"));
+        execute();
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowPropertiesCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowPropertiesCommandTest.java
@@ -15,11 +15,8 @@
  */
 package org.komodo.shell.commands;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import org.junit.Test;
 import org.komodo.shell.AbstractCommandTest;
-import org.komodo.shell.api.CommandResult;
 
 /**
  * Test Class to test {@link ShowPropertiesCommand}.
@@ -27,36 +24,27 @@ import org.komodo.shell.api.CommandResult;
 @SuppressWarnings({"javadoc", "nls"})
 public class ShowPropertiesCommandTest extends AbstractCommandTest {
 
-    @Test
+    @Test( expected = AssertionError.class )
     public void shouldNotBeAvailableAtLibrary() throws Exception {
         final String[] commands = { "library",
                                     "show-properties" };
         setup( commands );
-
-        final CommandResult result = execute();
-        assertThat( result.isOk(), is( false ) );
-        assertThat( result.getMessage(), result.getMessage().contains( ShowPropertiesCommand.NAME ), is( true ) );
+        execute();
     }
 
-    @Test
+    @Test( expected = AssertionError.class )
     public void shouldNotBeAvailableAtRoot() throws Exception {
         final String[] commands = { "show-properties" };
         setup( commands );
-
-        final CommandResult result = execute();
-        assertThat( result.isOk(), is( false ) );
-        assertThat( result.getMessage(), result.getMessage().contains( ShowPropertiesCommand.NAME ), is( true ) );
+        execute();
     }
 
-    @Test
+    @Test( expected = AssertionError.class )
     public void shouldNotBeAvailableAtWorkspace() throws Exception {
         final String[] commands = { "workspace",
                                     "show-properties" };
         setup( commands );
-
-        final CommandResult result = execute();
-        assertThat( result.isOk(), is( false ) );
-        assertThat( result.getMessage(), result.getMessage().contains( ShowPropertiesCommand.NAME ), is( true ) );
+        execute();
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowPropertyCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowPropertyCommandTest.java
@@ -15,11 +15,8 @@
  */
 package org.komodo.shell.commands;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import org.junit.Test;
 import org.komodo.shell.AbstractCommandTest;
-import org.komodo.shell.api.CommandResult;
 
 /**
  * Test Class to test {@link ShowPropertyCommand}.
@@ -27,36 +24,27 @@ import org.komodo.shell.api.CommandResult;
 @SuppressWarnings({"javadoc", "nls"})
 public class ShowPropertyCommandTest extends AbstractCommandTest {
 
-    @Test
+    @Test( expected = AssertionError.class )
     public void shouldNotBeAvailableAtLibrary() throws Exception {
         final String[] commands = { "library",
                                     "show-property test" };
         setup( commands );
-
-        final CommandResult result = execute();
-        assertThat( result.isOk(), is( false ) );
-        assertThat( result.getMessage(), result.getMessage().contains( ShowPropertyCommand.NAME ), is( true ) );
+        execute();
     }
 
-    @Test
+    @Test( expected = AssertionError.class )
     public void shouldNotBeAvailableAtRoot() throws Exception {
         final String[] commands = { "show-property test" };
         setup( commands );
-
-        final CommandResult result = execute();
-        assertThat( result.isOk(), is( false ) );
-        assertThat( result.getMessage(), result.getMessage().contains( ShowPropertyCommand.NAME ), is( true ) );
+        execute();
     }
 
-    @Test
+    @Test( expected = AssertionError.class )
     public void shouldNotBeAvailableAtWorkspace() throws Exception {
         final String[] commands = { "workspace",
                                     "show-property test" };
         setup( commands );
-
-        final CommandResult result = execute();
-        assertThat( result.isOk(), is( false ) );
-        assertThat( result.getMessage(), result.getMessage().contains( ShowPropertyCommand.NAME ), is( true ) );
+        execute();
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowSummaryCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowSummaryCommandTest.java
@@ -18,10 +18,10 @@ package org.komodo.shell.commands;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import org.junit.Test;
-import org.komodo.repository.ObjectImpl;
 import org.komodo.shell.AbstractCommandTest;
 import org.komodo.shell.api.CommandResult;
 import org.komodo.shell.api.KomodoObjectLabelProvider;
+import org.komodo.spi.repository.KomodoObject;
 
 /**
  * Test Class to test {@link ShowSummaryCommand}.
@@ -39,7 +39,7 @@ public class ShowSummaryCommandTest extends AbstractCommandTest {
         assertCommandResultOk(result);
 
         String writerOutput = getCommandOutput();
-        assertThat( writerOutput, writerOutput.contains( ObjectImpl.class.getSimpleName()
+        assertThat( writerOutput, writerOutput.contains( KomodoObject.class.getSimpleName()
                                                          + " \""
                                                          + KomodoObjectLabelProvider.LIB_DISPLAY_PATH
                                                          + "\"" ),
@@ -55,7 +55,7 @@ public class ShowSummaryCommandTest extends AbstractCommandTest {
         assertCommandResultOk(result);
 
         String writerOutput = getCommandOutput();
-        assertThat( writerOutput, writerOutput.contains( ObjectImpl.class.getSimpleName()
+        assertThat( writerOutput, writerOutput.contains( KomodoObject.class.getSimpleName()
                                                          + " \""
                                                          + KomodoObjectLabelProvider.ROOT_DISPLAY_NAME
                                                          + "\"" ),
@@ -72,7 +72,7 @@ public class ShowSummaryCommandTest extends AbstractCommandTest {
         assertCommandResultOk(result);
 
         String writerOutput = getCommandOutput();
-        assertThat( writerOutput, writerOutput.contains( ObjectImpl.class.getSimpleName()
+        assertThat( writerOutput, writerOutput.contains( KomodoObject.class.getSimpleName()
                                                          + " \""
                                                          + KomodoObjectLabelProvider.WORKSPACE_DISPLAY_PATH
                                                          + "\"" ),

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/WorkspaceCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/WorkspaceCommandTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.komodo.shell.AbstractCommandTest;
 import org.komodo.shell.api.CommandResult;
-import org.komodo.shell.commands.WorkspaceCommand;
 import org.komodo.shell.util.KomodoObjectUtils;
 
 /**


### PR DESCRIPTION
- wrapped the UnitOfWork in WorkspaceStatus such that when commit and rollback are called directly they call the appropriate WorkspaceStatus method.
- changed ShellCommandProvider to return a Set of ShellCommands instead of a Collection.
- the WorkspaceStatus UnitOfWork should not be cached. Fixed some instances where it was.
- changed ShellCommandFactory.getCommandNamesForCurrentContext to return a Set instead of a Collection
- added AddChildCommand and test
- removed references to VDB in the built-in shell command help and examples
